### PR TITLE
test: enable race detector in make test-unit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ lint:
 	cd ui && npm ci && npm run lint:fix
 
 test-unit: 
-	go test -tags=test -v ./manager/... ./edge/... ./navctl/... ./pkg/...
+	go test -race -tags=test -v ./manager/... ./edge/... ./navctl/... ./pkg/...
 
 generate: clean
 	cd api && buf generate


### PR DESCRIPTION
## Summary
- Add `-race` flag to the `test-unit` target in Makefile to enable Go's race detector during testing
- All existing tests pass with race detection enabled, confirming no current race conditions in the codebase
- Improves test coverage by detecting potential concurrency issues during development

## Test plan
- [x] Run `make test-unit` with race detector enabled
- [x] Verify all tests pass without race condition failures
- [x] Confirm quality checks (`make check`) pass with the changes