### PR TITLE
feat(ci): add nightly build system for main branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,145 @@
+name: Nightly Build
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    # Allow manual trigger
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    name: cleanup old nightly releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Delete old nightly releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get all nightly releases older than 7 days
+          CUTOFF_DATE=$(date -d '7 days ago' --iso-8601)
+          
+          # List all releases and filter for nightly ones older than cutoff
+          gh api repos/${{ github.repository }}/releases \
+            --jq ".[] | select(.tag_name | test(\"nightly\")) | select(.created_at < \"${CUTOFF_DATE}\") | .id" \
+            | while read release_id; do
+              echo "Deleting old nightly release ID: $release_id"
+              gh api -X DELETE repos/${{ github.repository }}/releases/$release_id || true
+            done
+
+  nightly:
+    name: nightly build
+    runs-on: ubuntu-latest
+    needs: cleanup
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v22
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate nightly version
+        id: version
+        run: |
+          # Generate nightly version in format: v0.0.0-nightly.YYYYMMDD
+          NIGHTLY_VERSION="v0.0.0-nightly.$(date +%Y%m%d)"
+          echo "version=$NIGHTLY_VERSION" >> $GITHUB_OUTPUT
+          echo "Generated nightly version: $NIGHTLY_VERSION"
+
+      - name: Build with GoReleaser
+        run: nix develop --command goreleaser build --config .goreleaser.nightly.yaml --snapshot --clean
+        env:
+          NIGHTLY_VERSION: ${{ steps.version.outputs.version }}
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create release with proper nightly description
+          gh release create ${{ steps.version.outputs.version }} \
+            --title "🌙 Nightly Build - ${{ steps.version.outputs.version }}" \
+            --notes "**⚠️ This is a nightly development build from the latest main branch.**
+
+          Nightly builds are:
+          - ✅ Built automatically from the latest main branch  
+          - ✅ Contain the newest features and bug fixes
+          - ⚠️  May contain unstable or experimental code
+          - ⚠️  Not recommended for production use
+          - 🔄 Released daily (older nightlies are automatically cleaned up)
+
+          For stable releases, see: [Latest Stable Release](https://github.com/liamawhite/navigator/releases/latest)
+
+          ## 🚀 Installation
+
+          ### Quick Install Scripts
+
+          #### Linux (x86_64)
+          \`\`\`bash
+          curl -L https://github.com/liamawhite/navigator/releases/download/${{ steps.version.outputs.version }}/navigator_Linux_x86_64.tar.gz | tar xz
+          chmod +x navctl
+          sudo mv navctl /usr/local/bin/
+          \`\`\`
+
+          #### Linux (ARM64)
+          \`\`\`bash
+          curl -L https://github.com/liamawhite/navigator/releases/download/${{ steps.version.outputs.version }}/navigator_Linux_arm64.tar.gz | tar xz
+          chmod +x navctl
+          sudo mv navctl /usr/local/bin/
+          \`\`\`
+
+          #### macOS (Intel)
+          \`\`\`bash
+          curl -L https://github.com/liamawhite/navigator/releases/download/${{ steps.version.outputs.version }}/navigator_Darwin_x86_64.tar.gz | tar xz
+          chmod +x navctl
+          sudo mv navctl /usr/local/bin/
+          \`\`\`
+
+          #### macOS (Apple Silicon)
+          \`\`\`bash
+          curl -L https://github.com/liamawhite/navigator/releases/download/${{ steps.version.outputs.version }}/navigator_Darwin_arm64.tar.gz | tar xz
+          chmod +x navctl
+          sudo mv navctl /usr/local/bin/
+          \`\`\`
+
+          #### Windows (PowerShell)
+          \`\`\`powershell
+          Invoke-WebRequest -Uri \"https://github.com/liamawhite/navigator/releases/download/${{ steps.version.outputs.version }}/navigator_Windows_x86_64.zip\" -OutFile \"navigator.zip\"
+          Expand-Archive -Path \"navigator.zip\" -DestinationPath \".\"
+          # Move navctl.exe to a directory in your PATH
+          \`\`\`
+
+          ### 🔍 Verify Installation
+          \`\`\`bash
+          navctl version
+          # Should show version ${{ steps.version.outputs.version }} with today's date
+          \`\`\`
+
+          ### 🛡️ Verification with Checksums
+          Download \`checksums.txt\` and verify your binary:
+          \`\`\`bash
+          # Linux/macOS
+          sha256sum -c checksums.txt
+
+          # Windows
+          certutil -hashfile navctl.exe SHA256
+          \`\`\`
+
+          ---
+
+          **💡 Tip**: To get notified of new nightly builds, watch this repository and select \"Releases only\" in your notification settings.
+
+          Released by [GoReleaser](https://github.com/goreleaser/goreleaser) | 🌙 Nightly Build Pipeline" \
+            --prerelease \
+            dist/*.tar.gz dist/*.zip dist/checksums.txt

--- a/.goreleaser.nightly.yaml
+++ b/.goreleaser.nightly.yaml
@@ -1,0 +1,60 @@
+# GoReleaser configuration for nightly builds
+# This configuration is specifically for automated nightly releases from main branch
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - sh -c 'cd ui && npm ci && npm run build'
+
+builds:
+  - id: navctl
+    main: ./navctl/main.go
+    binary: navctl
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X github.com/liamawhite/navigator/pkg/version.version={{.Version}}
+      - -X github.com/liamawhite/navigator/pkg/version.commit={{.FullCommit}}
+      - -X github.com/liamawhite/navigator/pkg/version.date={{.Date}}
+
+archives:
+  - id: navctl
+    ids: [navctl]
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  version_template: "{{ .Env.NIGHTLY_VERSION }}"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+
+# Release is handled manually via GitHub CLI in the workflow
+release:
+  disable: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,29 @@ Navigator is an edge computing platform that provides Kubernetes service discove
 4. UI queries manager's HTTP gateway for service information
 5. On-demand proxy analysis: Manager requests detailed config from specific edges
 
+## Installation
+
+### Stable Release (Recommended)
+Download the latest stable release from [GitHub Releases](https://github.com/liamawhite/navigator/releases/latest).
+
+### Nightly Builds (Development)
+For early access to new features, use nightly builds which are automatically generated daily from the main branch:
+
+```bash
+# Linux (x86_64)
+curl -L https://github.com/liamawhite/navigator/releases/download/$(curl -s https://api.github.com/repos/liamawhite/navigator/releases | jq -r '.[] | select(.prerelease == true and (.tag_name | contains("nightly"))) | .tag_name' | head -1)/navigator_Linux_x86_64.tar.gz | tar xz
+chmod +x navctl && sudo mv navctl /usr/local/bin/
+
+# macOS (Apple Silicon)
+curl -L https://github.com/liamawhite/navigator/releases/download/$(curl -s https://api.github.com/repos/liamawhite/navigator/releases | jq -r '.[] | select(.prerelease == true and (.tag_name | contains("nightly"))) | .tag_name' | head -1)/navigator_Darwin_arm64.tar.gz | tar xz
+chmod +x navctl && sudo mv navctl /usr/local/bin/
+
+# Verify installation
+navctl version
+```
+
+**⚠️ Nightly Build Notice**: Nightly builds contain the latest features but may be unstable. Use stable releases for production.
+
 ## Development Commands
 
 ### Quick Start


### PR DESCRIPTION
## Summary
- Add automated nightly builds from main branch with daily schedule at 2 AM UTC
- Create dedicated GoReleaser configuration for nightly releases with pre-release marking
- Implement auto-cleanup system to remove nightly builds older than 7 days
- Add comprehensive installation instructions for all platforms (Linux, macOS, Windows)
- Update CLAUDE.md with nightly build installation guide and usage notes