### PR TITLE
fix: correct image link path in architecture docs

### DIFF
--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -4,7 +4,7 @@ Navigator runs all components on your local machine or a dedicated server outsid
 
 ## navctl local Architecture
 
-![navctl Local Architecture](./navctl-local-architecture.svg)
+![navctl Local Architecture](./diagrams/navctl-local-architecture.svg)
 
 **Characteristics:**
 - **Single process**: Manager, multiple Edge instances, and UI run within one `navctl local` process


### PR DESCRIPTION
Fixes #70

The navctl-local-architecture.svg was referenced with an incorrect path in the architecture documentation. Updated the image reference to point to the correct location in the diagrams/ subdirectory.

Generated with [Claude Code](https://claude.ai/code)