### PR TITLE
feat(istio): add Prometheus addon with NodePort and Fortio load generation

### DIFF
--- a/pkg/localenv/fortio/fortio.go
+++ b/pkg/localenv/fortio/fortio.go
@@ -1,0 +1,195 @@
+// Copyright 2025 Navigator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fortio
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	fortioNamespace = "microservices"
+	fortioPodName   = "fortio-load"
+)
+
+// FortioManager manages Fortio load generation
+type FortioManager struct {
+	kubeconfig string
+	namespace  string
+	logger     *slog.Logger
+}
+
+// NewFortioManager creates a new Fortio manager instance
+func NewFortioManager(kubeconfig, namespace string, logger *slog.Logger) *FortioManager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if namespace == "" {
+		namespace = fortioNamespace
+	}
+
+	return &FortioManager{
+		kubeconfig: kubeconfig,
+		namespace:  namespace,
+		logger:     logger,
+	}
+}
+
+// InstallFortio deploys the Fortio load generation pod
+func (f *FortioManager) InstallFortio(ctx context.Context) error {
+	f.logger.Info("Installing Fortio load generator", "namespace", f.namespace)
+
+	// Get the manifest file path
+	manifestPath, err := f.getFortioManifestPath()
+	if err != nil {
+		return fmt.Errorf("failed to get manifest path: %w", err)
+	}
+
+	// Apply the manifest using kubectl
+	if err := f.applyManifest(ctx, manifestPath); err != nil {
+		return fmt.Errorf("failed to apply Fortio manifest: %w", err)
+	}
+
+	f.logger.Info("Fortio load generator installed successfully", "namespace", f.namespace)
+	return nil
+}
+
+// UninstallFortio removes the Fortio load generation pod
+func (f *FortioManager) UninstallFortio(ctx context.Context) error {
+	f.logger.Info("Uninstalling Fortio load generator", "namespace", f.namespace)
+
+	// Delete the pod using kubectl
+	// #nosec G204 -- fortioPodName and f.namespace are constants/validated inputs
+	cmd := exec.CommandContext(ctx, "kubectl", "delete", "pod", fortioPodName, "-n", f.namespace, "--ignore-not-found=true")
+	if f.kubeconfig != "" {
+		cmd.Args = append([]string{"kubectl", "--kubeconfig", f.kubeconfig}, cmd.Args[1:]...)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to delete Fortio pod: %w, output: %s", err, string(output))
+	}
+
+	f.logger.Info("Fortio load generator uninstalled successfully", "namespace", f.namespace)
+	return nil
+}
+
+// IsFortioRunning checks if the Fortio pod is running
+func (f *FortioManager) IsFortioRunning(ctx context.Context) (bool, error) {
+	f.logger.Debug("Checking if Fortio is running", "namespace", f.namespace)
+
+	// Check for Fortio pod
+	// #nosec G204 -- fortioPodName and f.namespace are constants/validated inputs
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "pod", fortioPodName, "-n", f.namespace, "--no-headers")
+	if f.kubeconfig != "" {
+		cmd.Args = append([]string{"kubectl", "--kubeconfig", f.kubeconfig}, cmd.Args[1:]...)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// If the command fails, Fortio is likely not running
+		f.logger.Debug("Fortio pod not found", "error", err, "output", string(output))
+		return false, nil
+	}
+
+	// Check if the pod is in Running state
+	outputStr := string(output)
+	isRunning := strings.Contains(outputStr, "Running")
+
+	f.logger.Debug("Fortio pod status", "output", outputStr, "running", isRunning)
+	return isRunning, nil
+}
+
+// WaitForFortioReady waits for the Fortio pod to become ready
+func (f *FortioManager) WaitForFortioReady(ctx context.Context, timeout time.Duration) error {
+	f.logger.Info("Waiting for Fortio to be ready", "timeout", timeout, "namespace", f.namespace)
+
+	// Wait for the pod to be ready
+	// #nosec G204 -- fortioPodName and f.namespace are constants/validated inputs
+	cmd := exec.CommandContext(ctx, "kubectl", "wait", "--for=condition=ready",
+		fmt.Sprintf("pod/%s", fortioPodName), "-n", f.namespace, fmt.Sprintf("--timeout=%s", timeout))
+
+	if f.kubeconfig != "" {
+		cmd.Args = append([]string{"kubectl", "--kubeconfig", f.kubeconfig}, cmd.Args[1:]...)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("fortio pod not ready within timeout: %w, output: %s", err, string(output))
+	}
+
+	f.logger.Info("Fortio is ready and generating load", "namespace", f.namespace)
+	return nil
+}
+
+// GetFortioLogs returns the logs from the Fortio pod
+func (f *FortioManager) GetFortioLogs(ctx context.Context) (string, error) {
+	// #nosec G204 -- fortioPodName and f.namespace are constants/validated inputs
+	cmd := exec.CommandContext(ctx, "kubectl", "logs", fortioPodName, "-n", f.namespace)
+	if f.kubeconfig != "" {
+		cmd.Args = append([]string{"kubectl", "--kubeconfig", f.kubeconfig}, cmd.Args[1:]...)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to get Fortio logs: %w", err)
+	}
+
+	return string(output), nil
+}
+
+// getFortioManifestPath returns the path to the Fortio manifest file
+func (f *FortioManager) getFortioManifestPath() (string, error) {
+	// Get the directory of this Go file
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("failed to get current file path")
+	}
+
+	// Build path to manifests directory
+	manifestPath := filepath.Join(filepath.Dir(currentFile), "manifests", "fortio.yaml")
+
+	// Check if the file exists
+	if _, err := os.Stat(manifestPath); err != nil {
+		return "", fmt.Errorf("manifest file not found at %s: %w", manifestPath, err)
+	}
+
+	return manifestPath, nil
+}
+
+// applyManifest applies a Kubernetes manifest using kubectl
+func (f *FortioManager) applyManifest(ctx context.Context, manifestPath string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", manifestPath)
+	if f.kubeconfig != "" {
+		cmd.Args = append([]string{"kubectl", "--kubeconfig", f.kubeconfig}, cmd.Args[1:]...)
+	}
+
+	f.logger.Debug("Applying Fortio manifest", "command", strings.Join(cmd.Args, " "))
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kubectl apply failed: %w, output: %s", err, string(output))
+	}
+
+	f.logger.Debug("Fortio manifest applied successfully", "output", string(output))
+	return nil
+}

--- a/pkg/localenv/fortio/manifests/fortio.yaml
+++ b/pkg/localenv/fortio/manifests/fortio.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fortio-load
+  namespace: microservices
+  labels:
+    app: fortio-load
+    app.kubernetes.io/name: fortio
+    app.kubernetes.io/component: load-generator
+    app.kubernetes.io/managed-by: navigator
+spec:
+  containers:
+  - name: fortio
+    image: fortio/fortio
+    args:
+    - load
+    - -qps
+    - "5"               # 5 requests per second
+    - -t
+    - "0"               # Run indefinitely (until stopped)
+    - -c
+    - "2"               # Use 2 concurrent connections
+    - -keepalive        # Keep connections alive for efficiency
+    - -logger-force-color=false  # Disable color for cleaner logs
+    - http://istio-ingressgateway.istio-system.svc.cluster.local/proxy/backend:8080/proxy/database:8080
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "100m"
+      limits:
+        memory: "128Mi"
+        cpu: "200m"
+  restartPolicy: OnFailure

--- a/pkg/localenv/istio/charts/1.24.6/prometheus.yaml
+++ b/pkg/localenv/istio/charts/1.24.6/prometheus.yaml
@@ -1,0 +1,578 @@
+# This Prometheus manifest has been modified by Navigator for local Kind cluster usage:
+# - Service type changed from ClusterIP to NodePort
+# - Fixed nodePort 30090 added for consistent localhost access
+# - Original source: https://raw.githubusercontent.com/istio/istio/VERSION/samples/addons/prometheus.yaml
+#
+---
+# Source: prometheus/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.54.1
+    helm.sh/chart: prometheus-25.27.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+  namespace: istio-system
+  annotations:
+    {}
+---
+# Source: prometheus/templates/cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.54.1
+    helm.sh/chart: prometheus-25.27.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+  namespace: istio-system
+data:
+  allow-snippet-annotations: "false"
+  alerting_rules.yml: |
+    {}
+  alerts: |
+    {}
+  prometheus.yml: |
+    global:
+      evaluation_interval: 1m
+      scrape_interval: 15s
+      scrape_timeout: 10s
+    rule_files:
+    - /etc/config/recording_rules.yml
+    - /etc/config/alerting_rules.yml
+    - /etc/config/rules
+    - /etc/config/alerts
+    scrape_configs:
+    - job_name: prometheus
+      static_configs:
+      - targets:
+        - localhost:9090
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-apiservers
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: default;kubernetes;https
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-nodes
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - replacement: kubernetes.default.svc:443
+        target_label: __address__
+      - regex: (.+)
+        replacement: /api/v1/nodes/$1/proxy/metrics
+        source_labels:
+        - __meta_kubernetes_node_name
+        target_label: __metrics_path__
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-nodes-cadvisor
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - replacement: kubernetes.default.svc:443
+        target_label: __address__
+      - regex: (.+)
+        replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+        source_labels:
+        - __meta_kubernetes_node_name
+        target_label: __metrics_path__
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - honor_labels: true
+      job_name: kubernetes-service-endpoints
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape
+      - action: drop
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (.+?)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+    - honor_labels: true
+      job_name: kubernetes-service-endpoints-slow
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (.+?)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+      scrape_interval: 5m
+      scrape_timeout: 30s
+    - honor_labels: true
+      job_name: prometheus-pushgateway
+      kubernetes_sd_configs:
+      - role: service
+      relabel_configs:
+      - action: keep
+        regex: pushgateway
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_probe
+    - honor_labels: true
+      job_name: kubernetes-services
+      kubernetes_sd_configs:
+      - role: service
+      metrics_path: /probe
+      params:
+        module:
+        - http_2xx
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_probe
+      - source_labels:
+        - __address__
+        target_label: __param_target
+      - replacement: blackbox
+        target_label: __address__
+      - source_labels:
+        - __param_target
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+    - honor_labels: true
+      job_name: kubernetes-pods
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+      - action: drop
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+        replacement: '[$2]:$1'
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: replace
+        regex: (\d+);((([0-9]+?)(\.|$)){4})
+        replacement: $2:$1
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: drop
+        regex: Pending|Succeeded|Failed|Completed
+        source_labels:
+        - __meta_kubernetes_pod_phase
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+    - honor_labels: true
+      job_name: kubernetes-pods-slow
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+        replacement: '[$2]:$1'
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: replace
+        regex: (\d+);((([0-9]+?)(\.|$)){4})
+        replacement: $2:$1
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: drop
+        regex: Pending|Succeeded|Failed|Completed
+        source_labels:
+        - __meta_kubernetes_pod_phase
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+      scrape_interval: 5m
+      scrape_timeout: 30s
+  recording_rules.yml: |
+    {}
+  rules: |
+    {}
+---
+# Source: prometheus/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.54.1
+    helm.sh/chart: prometheus-25.27.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - ingresses
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses/status
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get
+---
+# Source: prometheus/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.54.1
+    helm.sh/chart: prometheus-25.27.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+---
+# Source: prometheus/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.54.1
+    helm.sh/chart: prometheus-25.27.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+  namespace: istio-system
+spec:
+  ports:
+    - name: http
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+      # Added by Navigator: Fixed NodePort for consistent local access via localhost:30090
+      nodePort: 30090
+  selector:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+  sessionAffinity: None
+  # Modified by Navigator: Changed from ClusterIP to NodePort for local Kind cluster access
+  type: "NodePort"
+---
+# Source: prometheus/templates/deploy.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v2.54.1
+    helm.sh/chart: prometheus-25.27.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: prometheus
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/instance: prometheus
+        app.kubernetes.io/version: v2.54.1
+        helm.sh/chart: prometheus-25.27.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: prometheus
+        
+        sidecar.istio.io/inject: "false"
+    spec:
+      enableServiceLinks: true
+      serviceAccountName: prometheus
+      containers:
+        - name: prometheus-server-configmap-reload
+          image: "ghcr.io/prometheus-operator/prometheus-config-reloader:v0.76.0"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --watched-dir=/etc/config
+            - --listen-address=0.0.0.0:8080
+            - --reload-url=http://127.0.0.1:9090/-/reload
+          ports:
+            - containerPort: 8080
+              name: metrics
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+              scheme: HTTP
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+              scheme: HTTP
+            periodSeconds: 10
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+              readOnly: true
+
+        - name: prometheus-server
+          image: "prom/prometheus:v2.54.1"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --storage.tsdb.retention.time=15d
+            - --config.file=/etc/config/prometheus.yml
+            - --storage.tsdb.path=/data
+            - --web.console.libraries=/etc/prometheus/console_libraries
+            - --web.console.templates=/etc/prometheus/consoles
+            - --web.enable-lifecycle
+          ports:
+            - containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            timeoutSeconds: 4
+            failureThreshold: 3
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+            successThreshold: 1
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: storage-volume
+              mountPath: /data
+              subPath: ""
+      dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus
+        - name: storage-volume
+          emptyDir:
+            {}

--- a/pkg/localenv/istio/charts/1.25.4/prometheus.yaml
+++ b/pkg/localenv/istio/charts/1.25.4/prometheus.yaml
@@ -1,0 +1,571 @@
+# This Prometheus manifest has been modified by Navigator for local Kind cluster usage:
+# - Service type changed from ClusterIP to NodePort
+# - Fixed nodePort 30090 added for consistent localhost access
+# - Original source: https://raw.githubusercontent.com/istio/istio/VERSION/samples/addons/prometheus.yaml
+#
+---
+# Source: prometheus/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v3.1.0
+    helm.sh/chart: prometheus-26.1.0
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+  namespace: istio-system
+  annotations:
+    {}
+---
+# Source: prometheus/templates/cm.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v3.1.0
+    helm.sh/chart: prometheus-26.1.0
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+  namespace: istio-system
+data:
+  allow-snippet-annotations: "false"
+  alerting_rules.yml: |
+    {}
+  alerts: |
+    {}
+  prometheus.yml: |
+    global:
+      evaluation_interval: 1m
+      scrape_interval: 15s
+      scrape_timeout: 10s
+    rule_files:
+    - /etc/config/recording_rules.yml
+    - /etc/config/alerting_rules.yml
+    - /etc/config/rules
+    - /etc/config/alerts
+    scrape_configs:
+    - job_name: prometheus
+      static_configs:
+      - targets:
+        - localhost:9090
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-apiservers
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: default;kubernetes;https
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_service_name
+        - __meta_kubernetes_endpoint_port_name
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-nodes
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - replacement: kubernetes.default.svc:443
+        target_label: __address__
+      - regex: (.+)
+        replacement: /api/v1/nodes/$1/proxy/metrics
+        source_labels:
+        - __meta_kubernetes_node_name
+        target_label: __metrics_path__
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      job_name: kubernetes-nodes-cadvisor
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - replacement: kubernetes.default.svc:443
+        target_label: __address__
+      - regex: (.+)
+        replacement: /api/v1/nodes/$1/proxy/metrics/cadvisor
+        source_labels:
+        - __meta_kubernetes_node_name
+        target_label: __metrics_path__
+      scheme: https
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        insecure_skip_verify: true
+    - honor_labels: true
+      job_name: kubernetes-service-endpoints
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape
+      - action: drop
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (.+?)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+    - honor_labels: true
+      job_name: kubernetes-service-endpoints-slow
+      kubernetes_sd_configs:
+      - role: endpoints
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (.+?)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        source_labels:
+        - __address__
+        - __meta_kubernetes_service_annotation_prometheus_io_port
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_service_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+      scrape_interval: 5m
+      scrape_timeout: 30s
+    - honor_labels: true
+      job_name: prometheus-pushgateway
+      kubernetes_sd_configs:
+      - role: service
+      relabel_configs:
+      - action: keep
+        regex: pushgateway
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_probe
+    - honor_labels: true
+      job_name: kubernetes-services
+      kubernetes_sd_configs:
+      - role: service
+      metrics_path: /probe
+      params:
+        module:
+        - http_2xx
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_service_annotation_prometheus_io_probe
+      - source_labels:
+        - __address__
+        target_label: __param_target
+      - replacement: blackbox
+        target_label: __address__
+      - source_labels:
+        - __param_target
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - source_labels:
+        - __meta_kubernetes_service_name
+        target_label: service
+    - honor_labels: true
+      job_name: kubernetes-pods
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape
+      - action: drop
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+        replacement: '[$2]:$1'
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: replace
+        regex: (\d+);((([0-9]+?)(\.|$)){4})
+        replacement: $2:$1
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: drop
+        regex: Pending|Succeeded|Failed|Completed
+        source_labels:
+        - __meta_kubernetes_pod_phase
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+    - honor_labels: true
+      job_name: kubernetes-pods-slow
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - action: keep
+        regex: true
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scrape_slow
+      - action: replace
+        regex: (https?)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+        target_label: __scheme__
+      - action: replace
+        regex: (.+)
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_path
+        target_label: __metrics_path__
+      - action: replace
+        regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+        replacement: '[$2]:$1'
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: replace
+        regex: (\d+);((([0-9]+?)(\.|$)){4})
+        replacement: $2:$1
+        source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_port
+        - __meta_kubernetes_pod_ip
+        target_label: __address__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
+        replacement: __param_$1
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: drop
+        regex: Pending|Succeeded|Failed|Completed
+        source_labels:
+        - __meta_kubernetes_pod_phase
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_pod_node_name
+        target_label: node
+      scrape_interval: 5m
+      scrape_timeout: 30s
+  recording_rules.yml: |
+    {}
+  rules: |
+    {}
+---
+# Source: prometheus/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v3.1.0
+    helm.sh/chart: prometheus-26.1.0
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+      - ingresses
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses/status
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get
+---
+# Source: prometheus/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v3.1.0
+    helm.sh/chart: prometheus-26.1.0
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+---
+# Source: prometheus/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v3.1.0
+    helm.sh/chart: prometheus-26.1.0
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+  namespace: istio-system
+spec:
+  ports:
+    - name: http
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
+      # Added by Navigator: Fixed NodePort for consistent local access via localhost:30090
+      nodePort: 30090
+  selector:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+  sessionAffinity: None
+  # Modified by Navigator: Changed from ClusterIP to NodePort for local Kind cluster access
+  type: "NodePort"
+---
+# Source: prometheus/templates/deploy.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/version: v3.1.0
+    helm.sh/chart: prometheus-26.1.0
+    app.kubernetes.io/part-of: prometheus
+  name: prometheus
+  namespace: istio-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: server
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/instance: prometheus
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: server
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/instance: prometheus
+        app.kubernetes.io/version: v3.1.0
+        helm.sh/chart: prometheus-26.1.0
+        app.kubernetes.io/part-of: prometheus
+        
+        sidecar.istio.io/inject: "false"
+    spec:
+      enableServiceLinks: true
+      serviceAccountName: prometheus
+      containers:
+        - name: prometheus-server-configmap-reload
+          image: "ghcr.io/prometheus-operator/prometheus-config-reloader:v0.78.2"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --watched-dir=/etc/config
+            - --listen-address=0.0.0.0:8080
+            - --reload-url=http://127.0.0.1:9090/-/reload
+          ports:
+            - containerPort: 8080
+              name: metrics
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+              scheme: HTTP
+            initialDelaySeconds: 2
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+              scheme: HTTP
+            periodSeconds: 10
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+              readOnly: true
+
+        - name: prometheus-server
+          image: "prom/prometheus:v3.1.0"
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - --storage.tsdb.retention.time=15d
+            - --config.file=/etc/config/prometheus.yml
+            - --storage.tsdb.path=/data
+            - --web.console.libraries=/etc/prometheus/console_libraries
+            - --web.console.templates=/etc/prometheus/consoles
+            - --web.enable-lifecycle
+          ports:
+            - containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 5
+            timeoutSeconds: 4
+            failureThreshold: 3
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+            successThreshold: 1
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: storage-volume
+              mountPath: /data
+              subPath: ""
+      dnsPolicy: ClusterFirst
+      terminationGracePeriodSeconds: 300
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus
+        - name: storage-volume
+          emptyDir:
+            {}

--- a/pkg/localenv/istio/downloader/main.go
+++ b/pkg/localenv/istio/downloader/main.go
@@ -21,10 +21,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 const (
 	istioHelmRepoURL = "https://istio-release.storage.googleapis.com/charts"
+	// PrometheusNodePort matches the constant in pkg/localenv/kind/kind.go
+	// This ensures Prometheus is accessible on localhost:30090 in Kind clusters
+	prometheusNodePort = 30090
 )
 
 func main() {
@@ -40,14 +44,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Downloading Istio Helm charts for version %s...\n", version)
+	fmt.Printf("Downloading Istio Helm charts and addons for version %s...\n", version)
 
 	if err := downloadIstioCharts(version); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to download charts: %v\n", err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("Successfully downloaded Istio charts to pkg/localenv/istio/charts/\n")
+	if err := downloadIstioAddons(version); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to download addons: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Successfully downloaded Istio charts and addons to pkg/localenv/istio/charts/\n")
 }
 
 func validateVersion(version string) error {
@@ -87,6 +96,82 @@ func downloadIstioCharts(version string) error {
 			return fmt.Errorf("failed to download %s chart: %w", chart, err)
 		}
 		fmt.Printf("Downloaded %s chart\n", chart)
+	}
+
+	return nil
+}
+
+func downloadIstioAddons(version string) error {
+	// Get current working directory and go up to charts directory
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	// Create output directory in ../charts/{version}/
+	outputDir := filepath.Join(wd, "..", "charts", version)
+	if err := os.MkdirAll(outputDir, 0750); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	// Download Prometheus addon
+	if err := downloadPrometheusAddon(version, outputDir); err != nil {
+		return fmt.Errorf("failed to download Prometheus addon: %w", err)
+	}
+	fmt.Printf("Downloaded Prometheus addon\n")
+
+	return nil
+}
+
+func downloadPrometheusAddon(version, outputDir string) error {
+	// Construct download URL for Prometheus addon
+	prometheusURL := fmt.Sprintf("https://raw.githubusercontent.com/istio/istio/%s/samples/addons/prometheus.yaml", version)
+
+	fmt.Printf("Downloading Prometheus addon from %s\n", prometheusURL)
+
+	// Download the addon
+	// #nosec G107 -- prometheusURL is constructed from validated inputs
+	resp, err := http.Get(prometheusURL)
+	if err != nil {
+		return fmt.Errorf("failed to download Prometheus addon: %w", err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close response body: %v\n", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download Prometheus addon: HTTP %d", resp.StatusCode)
+	}
+
+	// Create the YAML file path
+	yamlFilePath := filepath.Join(outputDir, "prometheus.yaml")
+
+	// Create the YAML file
+	// #nosec G304 -- yamlFilePath is constructed from validated inputs
+	yamlFile, err := os.Create(yamlFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to create YAML file: %w", err)
+	}
+	defer func() {
+		if closeErr := yamlFile.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close YAML file: %v\n", closeErr)
+		}
+	}()
+
+	// Read the downloaded content
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Patch the Prometheus service to use NodePort for local Kind cluster access
+	patchedContent := patchPrometheusServiceForNodePort(string(content))
+
+	// Write the patched content to the YAML file
+	if _, err := yamlFile.WriteString(patchedContent); err != nil {
+		return fmt.Errorf("failed to write patched YAML file: %w", err)
 	}
 
 	return nil
@@ -136,4 +221,89 @@ func downloadChart(chartName, version, outputDir string) error {
 	}
 
 	return nil
+}
+
+// patchPrometheusServiceForNodePort modifies the Prometheus service configuration
+// to use NodePort instead of ClusterIP for direct access in Kind clusters
+func patchPrometheusServiceForNodePort(yamlContent string) string {
+	lines := strings.Split(yamlContent, "\n")
+	var result []string
+	var inPrometheusService bool
+	var inServiceSpec bool
+	var inServicePorts bool
+	var serviceModified bool
+
+	for i, line := range lines {
+		// Detect the start of the Prometheus service
+		if strings.Contains(line, "# Source: prometheus/templates/service.yaml") {
+			inPrometheusService = true
+			result = append(result, line)
+			continue
+		}
+
+		// Detect the end of the Prometheus service (next resource starts)
+		if inPrometheusService && strings.HasPrefix(line, "---") && i > 0 {
+			inPrometheusService = false
+			inServiceSpec = false
+			inServicePorts = false
+		}
+
+		// If we're in the Prometheus service, look for specific fields to modify
+		if inPrometheusService {
+			// Detect service spec section
+			if strings.HasPrefix(line, "spec:") {
+				inServiceSpec = true
+				result = append(result, line)
+				continue
+			}
+
+			// Detect ports section within service spec
+			if inServiceSpec && strings.HasPrefix(line, "  ports:") {
+				inServicePorts = true
+				result = append(result, line)
+				continue
+			}
+
+			// Modify the service type from ClusterIP to NodePort
+			if inServiceSpec && strings.Contains(line, `type: "ClusterIP"`) {
+				result = append(result, "  # Modified by Navigator: Changed from ClusterIP to NodePort for local Kind cluster access")
+				result = append(result, `  type: "NodePort"`)
+				serviceModified = true
+				continue
+			}
+
+			// Add nodePort to the http port configuration
+			if inServicePorts && strings.Contains(line, "targetPort: 9090") {
+				result = append(result, line)
+				// Add the nodePort on the next line with proper indentation
+				result = append(result, fmt.Sprintf("      # Added by Navigator: Fixed NodePort for consistent local access via localhost:%d", prometheusNodePort))
+				result = append(result, fmt.Sprintf("      nodePort: %d", prometheusNodePort))
+				continue
+			}
+
+			// End of service spec - reset flags
+			if inServiceSpec && strings.HasPrefix(line, "---") {
+				inServiceSpec = false
+				inServicePorts = false
+			}
+		}
+
+		// Add the line as-is
+		result = append(result, line)
+	}
+
+	modifiedContent := strings.Join(result, "\n")
+
+	// If we successfully modified the service, add a header comment
+	if serviceModified {
+		headerComment := `# This Prometheus manifest has been modified by Navigator for local Kind cluster usage:
+# - Service type changed from ClusterIP to NodePort
+# - Fixed nodePort 30090 added for consistent localhost access
+# - Original source: https://raw.githubusercontent.com/istio/istio/VERSION/samples/addons/prometheus.yaml
+#
+`
+		modifiedContent = headerComment + modifiedContent
+	}
+
+	return modifiedContent
 }

--- a/pkg/localenv/istio/prometheus.go
+++ b/pkg/localenv/istio/prometheus.go
@@ -1,0 +1,220 @@
+// Copyright 2025 Navigator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package istio
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	prometheusNamespace = "istio-system"
+)
+
+// PrometheusManager manages Prometheus addon installation
+type PrometheusManager struct {
+	kubeconfig string
+	namespace  string
+	logger     *slog.Logger
+}
+
+// NewPrometheusManager creates a new Prometheus manager instance
+func NewPrometheusManager(kubeconfig, namespace string, logger *slog.Logger) *PrometheusManager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if namespace == "" {
+		namespace = prometheusNamespace
+	}
+
+	return &PrometheusManager{
+		kubeconfig: kubeconfig,
+		namespace:  namespace,
+		logger:     logger,
+	}
+}
+
+// InstallPrometheusAddon installs the Prometheus addon using the embedded manifest
+func (p *PrometheusManager) InstallPrometheusAddon(ctx context.Context, version string) error {
+	p.logger.Info("Installing Prometheus addon", "version", version, "namespace", p.namespace)
+
+	// Get the Prometheus manifest from embedded files
+	manifestData, err := GetPrometheusManifest(version)
+	if err != nil {
+		return fmt.Errorf("failed to get Prometheus manifest: %w", err)
+	}
+
+	// Create temporary file for the manifest
+	tempFile, err := os.CreateTemp("", "prometheus-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file: %w", err)
+	}
+	defer func() {
+		if removeErr := os.Remove(tempFile.Name()); removeErr != nil {
+			p.logger.Warn("Failed to remove temporary file", "file", tempFile.Name(), "error", removeErr)
+		}
+	}()
+
+	// Write manifest to temporary file
+	if _, err := tempFile.Write(manifestData); err != nil {
+		return fmt.Errorf("failed to write manifest to temporary file: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary file: %w", err)
+	}
+
+	// Apply the manifest using kubectl
+	if err := p.applyManifest(ctx, tempFile.Name()); err != nil {
+		return fmt.Errorf("failed to apply Prometheus manifest: %w", err)
+	}
+
+	p.logger.Info("Prometheus addon installed successfully", "namespace", p.namespace)
+	return nil
+}
+
+// UninstallPrometheusAddon uninstalls the Prometheus addon
+func (p *PrometheusManager) UninstallPrometheusAddon(ctx context.Context, version string) error {
+	p.logger.Info("Uninstalling Prometheus addon", "version", version, "namespace", p.namespace)
+
+	// Get the Prometheus manifest from embedded files
+	manifestData, err := GetPrometheusManifest(version)
+	if err != nil {
+		return fmt.Errorf("failed to get Prometheus manifest: %w", err)
+	}
+
+	// Create temporary file for the manifest
+	tempFile, err := os.CreateTemp("", "prometheus-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file: %w", err)
+	}
+	defer func() {
+		if removeErr := os.Remove(tempFile.Name()); removeErr != nil {
+			p.logger.Warn("Failed to remove temporary file", "file", tempFile.Name(), "error", removeErr)
+		}
+	}()
+
+	// Write manifest to temporary file
+	if _, err := tempFile.Write(manifestData); err != nil {
+		return fmt.Errorf("failed to write manifest to temporary file: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary file: %w", err)
+	}
+
+	// Delete the manifest using kubectl
+	if err := p.deleteManifest(ctx, tempFile.Name()); err != nil {
+		return fmt.Errorf("failed to delete Prometheus manifest: %w", err)
+	}
+
+	p.logger.Info("Prometheus addon uninstalled successfully", "namespace", p.namespace)
+	return nil
+}
+
+// IsPrometheusInstalled checks if Prometheus is installed in the cluster
+func (p *PrometheusManager) IsPrometheusInstalled(ctx context.Context) (bool, error) {
+	p.logger.Debug("Checking if Prometheus is installed", "namespace", p.namespace)
+
+	// Check for Prometheus deployment
+	// #nosec G204 -- deployment name and p.namespace are validated inputs
+	cmd := exec.CommandContext(ctx, "kubectl", "get", "deployment", "prometheus", "-n", p.namespace)
+	if p.kubeconfig != "" {
+		cmd.Args = append([]string{"kubectl", "--kubeconfig", p.kubeconfig}, cmd.Args[1:]...)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// If the command fails, Prometheus is likely not installed
+		p.logger.Debug("Prometheus deployment not found", "error", err, "output", string(output))
+		return false, nil
+	}
+
+	p.logger.Debug("Prometheus deployment found", "output", string(output))
+	return true, nil
+}
+
+// WaitForPrometheusReady waits for Prometheus to become ready
+func (p *PrometheusManager) WaitForPrometheusReady(ctx context.Context, timeout time.Duration) error {
+	p.logger.Info("Waiting for Prometheus to be ready", "timeout", timeout, "namespace", p.namespace)
+
+	// Wait for the deployment to be ready
+	// #nosec G204 -- deployment name and p.namespace are validated inputs
+	cmd := exec.CommandContext(ctx, "kubectl", "wait", "--for=condition=available",
+		"deployment/prometheus", "-n", p.namespace, fmt.Sprintf("--timeout=%s", timeout))
+
+	if p.kubeconfig != "" {
+		cmd.Args = append([]string{"kubectl", "--kubeconfig", p.kubeconfig}, cmd.Args[1:]...)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("prometheus deployment not ready within timeout: %w, output: %s", err, string(output))
+	}
+
+	p.logger.Info("Prometheus is ready", "namespace", p.namespace)
+	return nil
+}
+
+// applyManifest applies a Kubernetes manifest using kubectl
+func (p *PrometheusManager) applyManifest(ctx context.Context, manifestPath string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "apply", "-f", manifestPath)
+	if p.kubeconfig != "" {
+		cmd.Args = append([]string{"kubectl", "--kubeconfig", p.kubeconfig}, cmd.Args[1:]...)
+	}
+
+	p.logger.Debug("Applying Prometheus manifest", "command", strings.Join(cmd.Args, " "))
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kubectl apply failed: %w, output: %s", err, string(output))
+	}
+
+	p.logger.Debug("Prometheus manifest applied successfully", "output", string(output))
+	return nil
+}
+
+// deleteManifest deletes a Kubernetes manifest using kubectl
+func (p *PrometheusManager) deleteManifest(ctx context.Context, manifestPath string) error {
+	cmd := exec.CommandContext(ctx, "kubectl", "delete", "-f", manifestPath, "--ignore-not-found=true")
+	if p.kubeconfig != "" {
+		cmd.Args = append([]string{"kubectl", "--kubeconfig", p.kubeconfig}, cmd.Args[1:]...)
+	}
+
+	p.logger.Debug("Deleting Prometheus manifest", "command", strings.Join(cmd.Args, " "))
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kubectl delete failed: %w, output: %s", err, string(output))
+	}
+
+	p.logger.Debug("Prometheus manifest deleted successfully", "output", string(output))
+	return nil
+}
+
+// GetPrometheusURL returns the URL for accessing Prometheus
+func (p *PrometheusManager) GetPrometheusURL(ctx context.Context) (string, error) {
+	p.logger.Info("Getting Prometheus URL", "namespace", p.namespace)
+
+	// For Kind clusters, we typically use port-forward or NodePort
+	// This is a simplified implementation that assumes port-forward access
+	prometheusURL := "http://localhost:9090"
+
+	p.logger.Info("Prometheus URL determined", "url", prometheusURL)
+	return prometheusURL, nil
+}

--- a/pkg/localenv/kind/kind.go
+++ b/pkg/localenv/kind/kind.go
@@ -35,6 +35,8 @@ const (
 	HTTPSNodePort = 30443
 	// StatusNodePort is the fixed NodePort for status/health checks (port 15021)
 	StatusNodePort = 31021
+	// PrometheusNodePort is the fixed NodePort for Prometheus metrics UI access (port 9090)
+	PrometheusNodePort = 30090
 )
 
 type KindManager struct {
@@ -174,11 +176,12 @@ func DefaultKindConfig(name string) KindClusterConfig {
 
 // DemoKindConfig returns a Kind configuration suitable for demo clusters with NodePort access
 func DemoKindConfig(name string) KindClusterConfig {
-	// Bind the specific fixed ports for Istio gateway access
+	// Bind the specific fixed ports for Istio gateway access and Prometheus metrics
 	portMaps := []string{
-		fmt.Sprintf("%d:%d", HTTPNodePort, HTTPNodePort),     // HTTP
-		fmt.Sprintf("%d:%d", HTTPSNodePort, HTTPSNodePort),   // HTTPS
-		fmt.Sprintf("%d:%d", StatusNodePort, StatusNodePort), // Status
+		fmt.Sprintf("%d:%d", HTTPNodePort, HTTPNodePort),             // HTTP - Microservices via Istio gateway
+		fmt.Sprintf("%d:%d", HTTPSNodePort, HTTPSNodePort),           // HTTPS - Microservices via Istio gateway
+		fmt.Sprintf("%d:%d", StatusNodePort, StatusNodePort),         // Status - Istio gateway health checks
+		fmt.Sprintf("%d:%d", PrometheusNodePort, PrometheusNodePort), // Prometheus - Metrics UI access
 	}
 
 	return KindClusterConfig{


### PR DESCRIPTION
## Summary
- Add Prometheus addon installation integrated with Istio setup
- Patch Prometheus service for direct NodePort access on localhost:30090
- Add Fortio load generator running continuous 5 RPS through full microservice chain
- Update Kind cluster configuration to expose Prometheus port mapping
- Integrate both components into demo command workflow with proper cleanup

## Test plan
- Build and run `./bin/navctl demo start` to verify:
  - Prometheus addon installs automatically with Istio
  - Prometheus UI accessible at http://localhost:30090
  - Fortio pod starts generating 5 RPS load through gateway→frontend→backend→database
  - All metrics visible in Prometheus dashboard
- Run `./bin/navctl demo stop` to verify proper cleanup of all components