### PR TITLE
refactor(fortio): move load generator to dedicated namespace

### DIFF
--- a/navctl/cmd/demo.go
+++ b/navctl/cmd/demo.go
@@ -206,7 +206,7 @@ and proxy analysis features.`,
 
 			// Start Fortio load generation
 			logger.Info("Starting continuous load generation at 5 RPS...")
-			fortioMgr := fortio.NewFortioManager(absKubeconfigPath, "microservices", logger)
+			fortioMgr := fortio.NewFortioManager(absKubeconfigPath, "load-generator", logger)
 			if err := fortioMgr.InstallFortio(ctx); err != nil {
 				logger.Warn("Failed to start Fortio load generator", "error", err)
 			} else {
@@ -278,7 +278,7 @@ This command deletes the specified Kind cluster and cleans up associated resourc
 		if _, err := filepath.Abs(kubeconfigPath); err == nil {
 			// Try to clean up Fortio load generator first (best effort)
 			logger.Info("Attempting Fortio cleanup")
-			fortioMgr := fortio.NewFortioManager(absKubeconfigPath, "microservices", logger)
+			fortioMgr := fortio.NewFortioManager(absKubeconfigPath, "load-generator", logger)
 			if running, err := fortioMgr.IsFortioRunning(ctx); err == nil && running {
 				logger.Info("Found Fortio load generator, cleaning up")
 				if err := fortioMgr.UninstallFortio(ctx); err != nil {

--- a/pkg/localenv/fortio/manifests/fortio.yaml
+++ b/pkg/localenv/fortio/manifests/fortio.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: fortio-load
-  namespace: microservices
+  namespace: load-generator
   labels:
     app: fortio-load
     app.kubernetes.io/name: fortio

--- a/pkg/localenv/fortio/manifests/load-generator-namespace.yaml
+++ b/pkg/localenv/fortio/manifests/load-generator-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: load-generator
+  labels:
+    name: load-generator
+    app.kubernetes.io/managed-by: navigator
+    # Explicitly disable Istio injection for this namespace
+    istio-injection: disabled


### PR DESCRIPTION
## Summary
- Refactor Fortio load generator to use dedicated `load-generator` namespace instead of `microservices`
- Add new namespace manifest with Istio injection explicitly disabled
- Update navctl demo command to use new namespace for both installation and cleanup
- Improve FortioManager to apply namespace manifest before Fortio deployment

## Test plan
- [ ] Verify navctl local demo starts Fortio in load-generator namespace
- [ ] Confirm namespace has Istio injection disabled
- [ ] Test cleanup properly removes load generator from new namespace
- [ ] Ensure existing functionality remains unchanged