### PR TITLE
feat(fortio): add external service load testing with example.com routing

### DIFF
--- a/pkg/localenv/fortio/manifests/fortio.yaml
+++ b/pkg/localenv/fortio/manifests/fortio.yaml
@@ -22,7 +22,43 @@ spec:
     - "2"               # Use 2 concurrent connections
     - -keepalive        # Keep connections alive for efficiency
     - -logger-force-color=false  # Disable color for cleaner logs
+    - -h2               # Use HTTP/2
     - http://istio-ingressgateway.istio-system.svc.cluster.local/proxy/backend:8080/proxy/database:8080
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "100m"
+      limits:
+        memory: "128Mi"
+        cpu: "200m"
+  restartPolicy: OnFailure
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fortio-external
+  namespace: load-generator
+  labels:
+    app: fortio-external
+    app.kubernetes.io/name: fortio-external
+    app.kubernetes.io/component: load-generator
+    app.kubernetes.io/managed-by: navigator
+spec:
+  containers:
+  - name: fortio
+    image: fortio/fortio
+    args:
+    - load
+    - -qps
+    - "5"               # 5 requests per second
+    - -t
+    - "0"               # Run indefinitely (until stopped)
+    - -c
+    - "2"               # Use 2 concurrent connections
+    - -keepalive        # Keep connections alive for efficiency
+    - -logger-force-color=false  # Disable color for cleaner logs
+    - -h2               # Use HTTP/2
+    - http://istio-ingressgateway.istio-system.svc.cluster.local/proxy/backend:8080/proxy/example.com:80
     resources:
       requests:
         memory: "64Mi"

--- a/pkg/localenv/istio/helm.go
+++ b/pkg/localenv/istio/helm.go
@@ -92,9 +92,14 @@ func NewHelmManager(kubeconfig, namespace string, logger *slog.Logger) (*HelmMan
 // DefaultIstioConfig returns default configuration for Istio installation
 func DefaultIstioConfig(version string) IstioInstallConfig {
 	return IstioInstallConfig{
-		Version:           version,
-		Namespace:         "istio-system",
-		Values:            map[string]interface{}{},
+		Version:   version,
+		Namespace: "istio-system",
+		Values: map[string]interface{}{
+			"meshConfig": map[string]interface{}{
+				"accessLogFile":   "/dev/stdout",
+				"accessLogFormat": "[%START_TIME%] \"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% \"%REQ(X-FORWARDED-FOR)%\" \"%REQ(USER-AGENT)%\" \"%REQ(X-REQUEST-ID)%\" \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%\n",
+			},
+		},
 		WaitTimeout:       5 * time.Minute,
 		InstallPrometheus: true,
 	}

--- a/pkg/localenv/microservice/manifests/backend/sidecar.yaml
+++ b/pkg/localenv/microservice/manifests/backend/sidecar.yaml
@@ -14,5 +14,6 @@ spec:
   - hosts:
     - "./database.microservices.svc.cluster.local"
     - "istio-system/*"
+    - "./example.com"
   outboundTrafficPolicy:
     mode: REGISTRY_ONLY

--- a/pkg/localenv/microservice/manifests/external-serviceentry.yaml
+++ b/pkg/localenv/microservice/manifests/external-serviceentry.yaml
@@ -1,0 +1,64 @@
+apiVersion: networking.istio.io/v1beta1
+kind: ServiceEntry
+metadata:
+  name: external-example-com
+  namespace: microservices
+  labels:
+    app.kubernetes.io/name: external-example-com
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/managed-by: navigator
+spec:
+  hosts:
+  - example.com
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  location: MESH_EXTERNAL
+  resolution: DNS
+  endpoints:
+  - address: istio-ingressgateway.istio-system.svc.cluster.local
+    ports:
+      http: 80  # HTTP port for ingress gateway
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: external-example-com
+  namespace: microservices
+  labels:
+    app.kubernetes.io/name: external-example-com-vs
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/managed-by: navigator
+spec:
+  hosts:
+  - example.com
+  http:
+  - route:
+    - destination:
+        host: istio-ingressgateway.istio-system.svc.cluster.local
+        port:
+          number: 80
+    timeout: 30s
+    retries:
+      attempts: 3
+      perTryTimeout: 10s
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: external-example-com
+  namespace: microservices
+  labels:
+    app.kubernetes.io/name: external-example-com-dr
+    app.kubernetes.io/component: networking
+    app.kubernetes.io/managed-by: navigator
+spec:
+  host: example.com
+  trafficPolicy:
+    connectionPool:
+      tcp:
+        maxConnections: 10
+      http:
+        http1MaxPendingRequests: 10
+        maxRequestsPerConnection: 2

--- a/pkg/localenv/microservice/manifests/kustomization.yaml
+++ b/pkg/localenv/microservice/manifests/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespace.yaml
   - gateway.yaml
   - peerauthentication.yaml
+  - external-serviceentry.yaml
   - frontend
   - backend
   - database


### PR DESCRIPTION
## Summary
- Add fortio-external pod that generates 5 RPS to example.com via backend for circular routing testing
- Create ServiceEntry mapping example.com to ingress gateway to enable traffic looping
- Configure VirtualService to route example.com requests back through ingress gateway
- Update backend sidecar egress hosts to allow example.com traffic (REGISTRY_ONLY mode requirement)  
- Enable HTTP/2 for both Fortio pods using -h2 flag for improved performance
- Add comprehensive Istio access logging format for enhanced traffic observability

## Traffic Flow
`fortio-external` → `ingress gateway` → `frontend` → `backend` → `example.com` (ServiceEntry) → `ingress gateway` → `frontend`

## Test Plan
- [x] Verify fortio-external pod starts and generates 5 RPS traffic
- [x] Confirm example.com ServiceEntry resolves to ingress gateway  
- [x] Check backend can make outbound requests to example.com
- [x] Validate HTTP/2 is used for Fortio → ingress gateway connections
- [x] Ensure HTTP/1.1 is used for backend → example.com ServiceEntry routing
- [x] Monitor access logs show complete circular routing pattern