### PR TITLE
feat(demo): add cluster name configuration to Istio installation

### DIFF
--- a/navctl/cmd/demo.go
+++ b/navctl/cmd/demo.go
@@ -324,8 +324,8 @@ func createSingleDemoCluster(ctx context.Context, clusterName string, clusterInd
 		return fmt.Errorf("failed to create Helm manager for Istio installation: %w", err)
 	}
 
-	// Install Istio
-	istioConfig := istio.DefaultIstioConfig(demoIstioVersion)
+	// Install Istio with cluster name
+	istioConfig := istio.DefaultIstioConfigWithCluster(demoIstioVersion, clusterName)
 	if err := helmMgr.InstallIstio(ctx, istioConfig); err != nil {
 		return fmt.Errorf("failed to install Istio: %w", err)
 	}

--- a/pkg/localenv/istio/helm.go
+++ b/pkg/localenv/istio/helm.go
@@ -108,14 +108,14 @@ func DefaultIstioConfig(version string) IstioInstallConfig {
 // DefaultIstioConfigWithCluster returns default configuration for Istio installation with cluster name
 func DefaultIstioConfigWithCluster(version, clusterName string) IstioInstallConfig {
 	config := DefaultIstioConfig(version)
-	
+
 	// Add cluster name to global configuration
 	config.Values["global"] = map[string]interface{}{
 		"multiCluster": map[string]interface{}{
 			"clusterName": clusterName,
 		},
 	}
-	
+
 	return config
 }
 

--- a/pkg/localenv/istio/helm.go
+++ b/pkg/localenv/istio/helm.go
@@ -105,6 +105,20 @@ func DefaultIstioConfig(version string) IstioInstallConfig {
 	}
 }
 
+// DefaultIstioConfigWithCluster returns default configuration for Istio installation with cluster name
+func DefaultIstioConfigWithCluster(version, clusterName string) IstioInstallConfig {
+	config := DefaultIstioConfig(version)
+	
+	// Add cluster name to global configuration
+	config.Values["global"] = map[string]interface{}{
+		"multiCluster": map[string]interface{}{
+			"clusterName": clusterName,
+		},
+	}
+	
+	return config
+}
+
 // InstallIstio installs Istio components in the correct order: base, istiod, gateway
 func (h *HelmManager) InstallIstio(ctx context.Context, config IstioInstallConfig) error {
 	h.logger.Info("Starting Istio installation",


### PR DESCRIPTION
## Summary
- Add cluster name configuration to Istio installation for demo clusters
- Create new `DefaultIstioConfigWithCluster` function that sets `global.multiCluster.clusterName`
- Update demo command to use cluster-specific Istio configuration
- Enable proper cluster identification in multi-cluster service discovery

## Changes
- **pkg/localenv/istio/helm.go**: Added `DefaultIstioConfigWithCluster()` function to configure cluster name in Istio values
- **navctl/cmd/demo.go**: Updated to use the new function with cluster name (e.g., "navigator-demo-1", "navigator-demo-2")

## Test Plan
- [ ] Build navctl binary successfully
- [ ] Run `navctl demo start` to create demo clusters
- [ ] Verify Istio installation includes cluster name configuration
- [ ] Test multi-cluster service discovery shows proper cluster identification

This addresses the issue where Navigator couldn't distinguish which cluster services belonged to in multi-cluster deployments.