### PR TITLE
feat(ui): add comprehensive sorting to service connections table

### DIFF
--- a/ui/src/components/serviceregistry/ServiceConnectionsTable.tsx
+++ b/ui/src/components/serviceregistry/ServiceConnectionsTable.tsx
@@ -60,6 +60,23 @@ interface SortState {
     direction: SortDirection;
 }
 
+// Constants for better maintainability
+const SORT_ICON_SIZE = 'w-3 h-3';
+const TRANSITION_DURATION = 'duration-200';
+const OPACITY_VALUES = {
+    INACTIVE: 'opacity-40',
+    HOVER: 'opacity-70',
+    ACTIVE: 'opacity-100'
+} as const;
+
+const MIN_REQUEST_RATE = 0.01;
+const SUCCESS_RATE_EXCELLENT = 99;
+const SUCCESS_RATE_GOOD = 95;
+
+const STORAGE_KEY = 'serviceConnections.sort';
+const DEFAULT_SORT_FIELD = 'requestRate';
+const DEFAULT_SORT_DIRECTION = 'desc';
+
 export const ServiceConnectionsTable: React.FC<
     ServiceConnectionsTableProps
 > = ({ inbound, outbound }) => {
@@ -68,7 +85,7 @@ export const ServiceConnectionsTable: React.FC<
     // Load sort preferences from localStorage with fallback to default
     const loadSortState = (): SortState => {
         try {
-            const saved = localStorage.getItem('serviceConnections.sort');
+            const saved = localStorage.getItem(STORAGE_KEY);
             if (saved) {
                 const parsed = JSON.parse(saved);
                 // Validate the loaded state
@@ -79,7 +96,7 @@ export const ServiceConnectionsTable: React.FC<
         } catch (error) {
             console.warn('Failed to load sort preferences:', error);
         }
-        return { field: 'requestRate', direction: 'desc' };
+        return { field: DEFAULT_SORT_FIELD, direction: DEFAULT_SORT_DIRECTION };
     };
 
     const [sortState, setSortState] = useState<SortState>(() =>
@@ -89,10 +106,7 @@ export const ServiceConnectionsTable: React.FC<
     // Save sort preferences to localStorage
     useEffect(() => {
         try {
-            localStorage.setItem(
-                'serviceConnections.sort',
-                JSON.stringify(sortState)
-            );
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(sortState));
         } catch (error) {
             console.warn('Failed to save sort preference:', error);
         }
@@ -155,10 +169,6 @@ export const ServiceConnectionsTable: React.FC<
         return 'text-red-600';
     };
 
-    // Configuration constants
-    const MIN_REQUEST_RATE = 0.01;
-    const SUCCESS_RATE_EXCELLENT = 99;
-    const SUCCESS_RATE_GOOD = 95;
 
     const processConnections = useCallback(
         (
@@ -282,18 +292,18 @@ export const ServiceConnectionsTable: React.FC<
     );
 
     const getSortIcon = (field: SortField, sortState: SortState) => {
-        const baseClasses = 'w-3 h-3 transition-all duration-200';
+        const baseClasses = `${SORT_ICON_SIZE} transition-all ${TRANSITION_DURATION}`;
 
         if (sortState.field !== field) {
-            return <ArrowUpDown className={`${baseClasses} opacity-40`} />;
+            return <ArrowUpDown className={`${baseClasses} ${OPACITY_VALUES.INACTIVE}`} />;
         }
 
         if (sortState.direction === 'asc') {
-            return <ArrowUp className={`${baseClasses} opacity-100`} />;
+            return <ArrowUp className={`${baseClasses} ${OPACITY_VALUES.ACTIVE}`} />;
         } else if (sortState.direction === 'desc') {
-            return <ArrowDown className={`${baseClasses} opacity-100`} />;
+            return <ArrowDown className={`${baseClasses} ${OPACITY_VALUES.ACTIVE}`} />;
         } else {
-            return <ArrowUpDown className={`${baseClasses} opacity-40`} />;
+            return <ArrowUpDown className={`${baseClasses} ${OPACITY_VALUES.INACTIVE}`} />;
         }
     };
 
@@ -354,8 +364,8 @@ export const ServiceConnectionsTable: React.FC<
                                 <div
                                     className={`transition-all duration-150 ${
                                         isActive
-                                            ? 'opacity-100'
-                                            : 'opacity-40 group-hover:opacity-70'
+                                            ? OPACITY_VALUES.ACTIVE
+                                            : `${OPACITY_VALUES.INACTIVE} group-hover:${OPACITY_VALUES.HOVER}`
                                     }`}
                                 >
                                     {getSortIcon(field, sortState)}

--- a/ui/src/components/serviceregistry/ServiceConnectionsTable.tsx
+++ b/ui/src/components/serviceregistry/ServiceConnectionsTable.tsx
@@ -66,7 +66,7 @@ const TRANSITION_DURATION = 'duration-200';
 const OPACITY_VALUES = {
     INACTIVE: 'opacity-40',
     HOVER: 'opacity-70',
-    ACTIVE: 'opacity-100'
+    ACTIVE: 'opacity-100',
 } as const;
 
 const MIN_REQUEST_RATE = 0.01;
@@ -168,7 +168,6 @@ export const ServiceConnectionsTable: React.FC<
         if (rate >= SUCCESS_RATE_GOOD) return 'text-amber-600';
         return 'text-red-600';
     };
-
 
     const processConnections = useCallback(
         (
@@ -295,15 +294,31 @@ export const ServiceConnectionsTable: React.FC<
         const baseClasses = `${SORT_ICON_SIZE} transition-all ${TRANSITION_DURATION}`;
 
         if (sortState.field !== field) {
-            return <ArrowUpDown className={`${baseClasses} ${OPACITY_VALUES.INACTIVE}`} />;
+            return (
+                <ArrowUpDown
+                    className={`${baseClasses} ${OPACITY_VALUES.INACTIVE}`}
+                />
+            );
         }
 
         if (sortState.direction === 'asc') {
-            return <ArrowUp className={`${baseClasses} ${OPACITY_VALUES.ACTIVE}`} />;
+            return (
+                <ArrowUp
+                    className={`${baseClasses} ${OPACITY_VALUES.ACTIVE}`}
+                />
+            );
         } else if (sortState.direction === 'desc') {
-            return <ArrowDown className={`${baseClasses} ${OPACITY_VALUES.ACTIVE}`} />;
+            return (
+                <ArrowDown
+                    className={`${baseClasses} ${OPACITY_VALUES.ACTIVE}`}
+                />
+            );
         } else {
-            return <ArrowUpDown className={`${baseClasses} ${OPACITY_VALUES.INACTIVE}`} />;
+            return (
+                <ArrowUpDown
+                    className={`${baseClasses} ${OPACITY_VALUES.INACTIVE}`}
+                />
+            );
         }
     };
 

--- a/ui/src/components/serviceregistry/ServiceConnectionsTable.tsx
+++ b/ui/src/components/serviceregistry/ServiceConnectionsTable.tsx
@@ -335,16 +335,17 @@ export const ServiceConnectionsTable: React.FC<
             sortState.field === field && sortState.direction !== null;
 
         const getTooltipText = () => {
-            if (isActive) {
-                const nextAction =
-                    sortState.direction === 'asc'
-                        ? 'descending'
-                        : sortState.direction === 'desc'
-                          ? 'default'
-                          : 'ascending';
-                return `Currently sorted ${sortState.direction}ending. Click to sort ${nextAction}.`;
+            const sortStates = {
+                asc: { current: 'ascending', next: 'descending' },
+                desc: { current: 'descending', next: 'default' },
+            };
+            
+            if (!isActive) {
+                return `Click to sort by ${children} (ascending first)`;
             }
-            return `Click to sort by ${children} (ascending first)`;
+            
+            const state = sortStates[sortState.direction];
+            return `Currently sorted ${state.current}. Click to sort ${state.next}.`;
         };
 
         // Determine alignment based on className

--- a/ui/src/components/serviceregistry/ServiceConnectionsTable.tsx
+++ b/ui/src/components/serviceregistry/ServiceConnectionsTable.tsx
@@ -339,11 +339,11 @@ export const ServiceConnectionsTable: React.FC<
                 asc: { current: 'ascending', next: 'descending' },
                 desc: { current: 'descending', next: 'default' },
             };
-            
+
             if (!isActive) {
                 return `Click to sort by ${children} (ascending first)`;
             }
-            
+
             const state = sortStates[sortState.direction];
             return `Currently sorted ${state.current}. Click to sort ${state.next}.`;
         };
@@ -410,20 +410,17 @@ export const ServiceConnectionsTable: React.FC<
         return `${service}.${namespace}`;
     };
 
-    const inboundConnections = useMemo(
-        () =>
-            sortConnections(processConnections(inbound, 'inbound'), sortState),
-        [inbound, sortState, processConnections, sortConnections]
-    );
+    const sortedData = useMemo(() => {
+        const inboundProcessed = processConnections(inbound, 'inbound');
+        const outboundProcessed = processConnections(outbound, 'outbound');
+        return {
+            inbound: sortConnections(inboundProcessed, sortState),
+            outbound: sortConnections(outboundProcessed, sortState),
+        };
+    }, [inbound, outbound, sortState, processConnections, sortConnections]);
 
-    const outboundConnections = useMemo(
-        () =>
-            sortConnections(
-                processConnections(outbound, 'outbound'),
-                sortState
-            ),
-        [outbound, sortState, processConnections, sortConnections]
-    );
+    const { inbound: inboundConnections, outbound: outboundConnections } =
+        sortedData;
 
     if (inboundConnections.length === 0 && outboundConnections.length === 0) {
         return (


### PR DESCRIPTION
## Summary
- Add clickable sortable headers for all columns (service, cluster, throughput, latency P99, success rate)
- Implement three-state sorting with visual feedback: ascending → descending → default
- Add keyboard navigation support and helpful tooltips for accessibility
- Implement persistent sort preferences using localStorage with RPS descending as default
- Consolidate to unified sort state for both inbound and outbound tables
- Fix header alignment issues to properly match data columns

## Test plan
- [ ] Verify all column headers are clickable and show proper sort icons
- [ ] Test three-state sorting cycle (asc → desc → default) for each column
- [ ] Confirm highest RPS services appear at top by default
- [ ] Check that sort preferences persist across page reloads
- [ ] Verify keyboard navigation works (Enter/Space to sort)
- [ ] Test tooltips show correct current state and next action
- [ ] Ensure both inbound and outbound tables sort consistently
- [ ] Confirm header text aligns properly with data columns