### PR TITLE
feat(edge): replace polling List calls with informer cache

### DIFF
--- a/edge/pkg/kubernetes/client.go
+++ b/edge/pkg/kubernetes/client.go
@@ -19,13 +19,17 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 
-	v1alpha1 "github.com/liamawhite/navigator/pkg/api/backend/v1alpha1"
-	typesv1alpha1 "github.com/liamawhite/navigator/pkg/api/types/v1alpha1"
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
-	corev1 "k8s.io/api/core/v1"
-	discoveryv1 "k8s.io/api/discovery/v1"
+	istioinformers "istio.io/client-go/pkg/informers/externalversions"
+	istiov1alpha3listers "istio.io/client-go/pkg/listers/networking/v1alpha3"
+	istiov1beta1listers "istio.io/client-go/pkg/listers/networking/v1beta1"
+	istioextlisters "istio.io/client-go/pkg/listers/extensions/v1alpha1"
+	istioseclisters "istio.io/client-go/pkg/listers/security/v1beta1"
+	appsv1lister "k8s.io/client-go/listers/apps/v1"
+	corev1lister "k8s.io/client-go/listers/core/v1"
+	discoveryv1lister "k8s.io/client-go/listers/discovery/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -37,6 +41,29 @@ type Client struct {
 	istioClient istioclient.Interface
 	restConfig  *rest.Config
 	logger      *slog.Logger
+
+	// informer factories (nil until Start is called)
+	k8sFactory   informers.SharedInformerFactory
+	istioFactory istioinformers.SharedInformerFactory
+
+	// k8s listers (populated by Start)
+	servicesLister       corev1lister.ServiceLister
+	podsLister           corev1lister.PodLister
+	endpointSlicesLister discoveryv1lister.EndpointSliceLister
+	deploymentsLister    appsv1lister.DeploymentLister
+	namespacesLister     corev1lister.NamespaceLister
+
+	// Istio listers (populated by Start)
+	destinationRulesLister       istiov1beta1listers.DestinationRuleLister
+	gatewaysLister               istiov1beta1listers.GatewayLister
+	sidecarsLister               istiov1beta1listers.SidecarLister
+	virtualServicesLister        istiov1beta1listers.VirtualServiceLister
+	serviceEntriesLister         istiov1beta1listers.ServiceEntryLister
+	envoyFiltersLister           istiov1alpha3listers.EnvoyFilterLister
+	requestAuthenticationsLister istioseclisters.RequestAuthenticationLister
+	peerAuthenticationsLister    istioseclisters.PeerAuthenticationLister
+	authorizationPoliciesLister  istioseclisters.AuthorizationPolicyLister
+	wasmPluginsLister            istioextlisters.WasmPluginLister
 }
 
 // NewClient creates a new Kubernetes client
@@ -100,6 +127,71 @@ func NewClientWithContext(kubeconfigPath string, contextName string, logger *slo
 	}, nil
 }
 
+// Start initialises informer factories, starts all informers, and waits for cache sync.
+// Must be called before GetClusterState.
+// Start initialises informer factories, starts all informers, and waits for cache sync.
+// Must be called before GetClusterState.
+func (k *Client) Start(ctx context.Context) error {
+	k.k8sFactory = informers.NewSharedInformerFactory(k.clientset, 0)
+	k.istioFactory = istioinformers.NewSharedInformerFactory(k.istioClient, 0)
+
+	// Call .Informer() on each to register them with the factory before Start.
+	// The factory only starts informers that have been registered via InformerFor.
+	k.k8sFactory.Core().V1().Services().Informer()
+	k.k8sFactory.Core().V1().Pods().Informer()
+	k.k8sFactory.Discovery().V1().EndpointSlices().Informer()
+	k.k8sFactory.Apps().V1().Deployments().Informer()
+	k.k8sFactory.Core().V1().Namespaces().Informer()
+
+	k.istioFactory.Networking().V1beta1().DestinationRules().Informer()
+	k.istioFactory.Networking().V1beta1().Gateways().Informer()
+	k.istioFactory.Networking().V1beta1().Sidecars().Informer()
+	k.istioFactory.Networking().V1beta1().VirtualServices().Informer()
+	k.istioFactory.Networking().V1beta1().ServiceEntries().Informer()
+	k.istioFactory.Networking().V1alpha3().EnvoyFilters().Informer()
+	k.istioFactory.Security().V1beta1().RequestAuthentications().Informer()
+	k.istioFactory.Security().V1beta1().PeerAuthentications().Informer()
+	k.istioFactory.Security().V1beta1().AuthorizationPolicies().Informer()
+	k.istioFactory.Extensions().V1alpha1().WasmPlugins().Informer()
+
+	k.k8sFactory.Start(ctx.Done())
+	k.istioFactory.Start(ctx.Done())
+
+	k8sSynced := k.k8sFactory.WaitForCacheSync(ctx.Done())
+	for _, ok := range k8sSynced {
+		if !ok {
+			return fmt.Errorf("k8s informer cache sync failed")
+		}
+	}
+
+	istioSynced := k.istioFactory.WaitForCacheSync(ctx.Done())
+	for _, ok := range istioSynced {
+		if !ok {
+			return fmt.Errorf("istio informer cache sync failed")
+		}
+	}
+
+	// InformerFor is idempotent; these calls return the already-registered informers.
+	k.servicesLister = k.k8sFactory.Core().V1().Services().Lister()
+	k.podsLister = k.k8sFactory.Core().V1().Pods().Lister()
+	k.endpointSlicesLister = k.k8sFactory.Discovery().V1().EndpointSlices().Lister()
+	k.deploymentsLister = k.k8sFactory.Apps().V1().Deployments().Lister()
+	k.namespacesLister = k.k8sFactory.Core().V1().Namespaces().Lister()
+
+	k.destinationRulesLister = k.istioFactory.Networking().V1beta1().DestinationRules().Lister()
+	k.gatewaysLister = k.istioFactory.Networking().V1beta1().Gateways().Lister()
+	k.sidecarsLister = k.istioFactory.Networking().V1beta1().Sidecars().Lister()
+	k.virtualServicesLister = k.istioFactory.Networking().V1beta1().VirtualServices().Lister()
+	k.serviceEntriesLister = k.istioFactory.Networking().V1beta1().ServiceEntries().Lister()
+	k.envoyFiltersLister = k.istioFactory.Networking().V1alpha3().EnvoyFilters().Lister()
+	k.requestAuthenticationsLister = k.istioFactory.Security().V1beta1().RequestAuthentications().Lister()
+	k.peerAuthenticationsLister = k.istioFactory.Security().V1beta1().PeerAuthentications().Lister()
+	k.authorizationPoliciesLister = k.istioFactory.Security().V1beta1().AuthorizationPolicies().Lister()
+	k.wasmPluginsLister = k.istioFactory.Extensions().V1alpha1().WasmPlugins().Lister()
+
+	return nil
+}
+
 // GetClientset returns the underlying Kubernetes clientset
 func (k *Client) GetClientset() kubernetes.Interface {
 	return k.clientset
@@ -110,15 +202,29 @@ func (k *Client) GetRestConfig() *rest.Config {
 	return k.restConfig
 }
 
-// GetClusterName retrieves the cluster name from Istio's CLUSTER_ID environment variable in istiod deployment
+// mergeErrors combines multiple errors into a single error with detailed information
+func (k *Client) mergeErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	msgs := make([]string, 0, len(errs))
+	for _, e := range errs {
+		msgs = append(msgs, e.Error())
+	}
+	return fmt.Errorf("multiple errors occurred (%d total): %s", len(errs), strings.Join(msgs, "; "))
+}
+
+// GetClusterName retrieves the cluster name from Istio's CLUSTER_ID environment variable in istiod deployment.
+// This uses direct API calls and must be called before Start.
 func (k *Client) GetClusterName(ctx context.Context) (string, error) {
-	// Discover the active Istio control plane
 	rootNamespace, activeDeployment := k.discoverIstioControlPlane(ctx)
 	if activeDeployment == nil {
 		return "", fmt.Errorf("no active istiod deployment found in namespace %s", rootNamespace)
 	}
 
-	// Extract CLUSTER_ID from the deployment
 	for _, container := range activeDeployment.Spec.Template.Spec.Containers {
 		if container.Name == "discovery" {
 			for _, env := range container.Env {
@@ -136,104 +242,4 @@ func (k *Client) GetClusterName(ctx context.Context) (string, error) {
 	}
 
 	return "", fmt.Errorf("CLUSTER_ID environment variable not found in istiod deployment %s/%s", activeDeployment.Namespace, activeDeployment.Name)
-}
-
-// GetClusterState discovers all services in the cluster and returns the cluster state
-func (k *Client) GetClusterState(ctx context.Context) (*v1alpha1.ClusterState, error) {
-	// Parallelize API calls and map building in single goroutines
-	var wg sync.WaitGroup
-	var servicesResult *corev1.ServiceList
-	var endpointSlicesByService map[string][]discoveryv1.EndpointSlice
-	var podsByName map[string]*corev1.Pod
-	var protoDestinationRules []*typesv1alpha1.DestinationRule
-	var protoEnvoyFilters []*typesv1alpha1.EnvoyFilter
-	var protoRequestAuthentications []*typesv1alpha1.RequestAuthentication
-	var protoPeerAuthentications []*typesv1alpha1.PeerAuthentication
-	var protoAuthorizationPolicies []*typesv1alpha1.AuthorizationPolicy
-	var protoWasmPlugins []*typesv1alpha1.WasmPlugin
-	var protoGateways []*typesv1alpha1.Gateway
-	var protoSidecars []*typesv1alpha1.Sidecar
-	var protoVirtualServices []*typesv1alpha1.VirtualService
-	var protoServiceEntries []*typesv1alpha1.ServiceEntry
-	var protoIstioControlPlaneConfig *typesv1alpha1.IstioControlPlaneConfig
-
-	// Create error channel to collect errors from all goroutines
-	errChan := make(chan error, 14)
-	wg.Add(14)
-
-	// Fetch Kubernetes resources concurrently
-	go k.fetchServices(ctx, &wg, &servicesResult, errChan)
-	go k.fetchEndpointSlices(ctx, &wg, &endpointSlicesByService, errChan)
-	go k.fetchPods(ctx, &wg, &podsByName, errChan)
-
-	// Fetch and convert Istio resources concurrently
-	go k.fetchDestinationRules(ctx, &wg, &protoDestinationRules, errChan)
-	go k.fetchEnvoyFilters(ctx, &wg, &protoEnvoyFilters, errChan)
-	go k.fetchRequestAuthentications(ctx, &wg, &protoRequestAuthentications, errChan)
-	go k.fetchPeerAuthentications(ctx, &wg, &protoPeerAuthentications, errChan)
-	go k.fetchAuthorizationPolicies(ctx, &wg, &protoAuthorizationPolicies, errChan)
-	go k.fetchWasmPlugins(ctx, &wg, &protoWasmPlugins, errChan)
-	go k.fetchGateways(ctx, &wg, &protoGateways, errChan)
-	go k.fetchSidecars(ctx, &wg, &protoSidecars, errChan)
-	go k.fetchVirtualServices(ctx, &wg, &protoVirtualServices, errChan)
-	go k.fetchServiceEntries(ctx, &wg, &protoServiceEntries, errChan)
-	go k.fetchIstioControlPlaneConfig(ctx, &wg, &protoIstioControlPlaneConfig, errChan)
-
-	// Wait for all goroutines to complete
-	wg.Wait()
-	close(errChan)
-
-	// Collect all errors from the channel
-	var errors []error
-	for err := range errChan {
-		if err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	// If we have any errors, merge them and return
-	if len(errors) > 0 {
-		return nil, k.mergeErrors(errors)
-	}
-
-	// Convert services using the fetched data
-	var protoServices []*v1alpha1.Service
-	for _, svc := range servicesResult.Items {
-		protoService := k.convertServiceWithMaps(&svc, endpointSlicesByService, podsByName)
-		protoServices = append(protoServices, protoService)
-	}
-
-	return &v1alpha1.ClusterState{
-		Services:                protoServices,
-		DestinationRules:        protoDestinationRules,
-		EnvoyFilters:            protoEnvoyFilters,
-		RequestAuthentications:  protoRequestAuthentications,
-		Gateways:                protoGateways,
-		Sidecars:                protoSidecars,
-		VirtualServices:         protoVirtualServices,
-		IstioControlPlaneConfig: protoIstioControlPlaneConfig,
-		PeerAuthentications:     protoPeerAuthentications,
-		AuthorizationPolicies:   protoAuthorizationPolicies,
-		WasmPlugins:             protoWasmPlugins,
-		ServiceEntries:          protoServiceEntries,
-	}, nil
-}
-
-// mergeErrors combines multiple errors into a single error with detailed information
-func (k *Client) mergeErrors(errors []error) error {
-	if len(errors) == 0 {
-		return nil
-	}
-	if len(errors) == 1 {
-		return errors[0]
-	}
-
-	var errorMessages []string
-	for _, err := range errors {
-		errorMessages = append(errorMessages, err.Error())
-	}
-
-	return fmt.Errorf("multiple errors occurred (%d total): %s",
-		len(errors),
-		strings.Join(errorMessages, "; "))
 }

--- a/edge/pkg/kubernetes/client.go
+++ b/edge/pkg/kubernetes/client.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
+	"sync"
 
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
@@ -41,6 +41,9 @@ type Client struct {
 	istioClient istioclient.Interface
 	restConfig  *rest.Config
 	logger      *slog.Logger
+
+	mu      sync.Mutex
+	started bool
 
 	// informer factories (nil until Start is called)
 	k8sFactory   informers.SharedInformerFactory
@@ -130,6 +133,17 @@ func NewClientWithContext(kubeconfigPath string, contextName string, logger *slo
 // Start initialises informer factories, starts all informers, and waits for cache sync.
 // Must be called before GetClusterState.
 func (k *Client) Start(ctx context.Context) error {
+	k.mu.Lock()
+	if k.started {
+		k.mu.Unlock()
+		return fmt.Errorf("kubernetes client already started")
+	}
+	k.started = true
+	k.mu.Unlock()
+
+	// Resync period 0: rely on watch events only. Periodic full-resync would
+	// add redundant API server load; missed events are recoverable via re-list
+	// on watch reconnect, which the informer machinery handles automatically.
 	k.k8sFactory = informers.NewSharedInformerFactory(k.clientset, 0)
 	k.istioFactory = istioinformers.NewSharedInformerFactory(k.istioClient, 0)
 
@@ -156,16 +170,16 @@ func (k *Client) Start(ctx context.Context) error {
 	k.istioFactory.Start(ctx.Done())
 
 	k8sSynced := k.k8sFactory.WaitForCacheSync(ctx.Done())
-	for _, ok := range k8sSynced {
+	for t, ok := range k8sSynced {
 		if !ok {
-			return fmt.Errorf("k8s informer cache sync failed")
+			return fmt.Errorf("k8s informer cache sync failed for %v", t)
 		}
 	}
 
 	istioSynced := k.istioFactory.WaitForCacheSync(ctx.Done())
-	for _, ok := range istioSynced {
+	for t, ok := range istioSynced {
 		if !ok {
-			return fmt.Errorf("istio informer cache sync failed")
+			return fmt.Errorf("istio informer cache sync failed for %v", t)
 		}
 	}
 
@@ -198,21 +212,6 @@ func (k *Client) GetClientset() kubernetes.Interface {
 // GetRestConfig returns the underlying Kubernetes REST config
 func (k *Client) GetRestConfig() *rest.Config {
 	return k.restConfig
-}
-
-// mergeErrors combines multiple errors into a single error with detailed information
-func (k *Client) mergeErrors(errs []error) error {
-	if len(errs) == 0 {
-		return nil
-	}
-	if len(errs) == 1 {
-		return errs[0]
-	}
-	msgs := make([]string, 0, len(errs))
-	for _, e := range errs {
-		msgs = append(msgs, e.Error())
-	}
-	return fmt.Errorf("multiple errors occurred (%d total): %s", len(errs), strings.Join(msgs, "; "))
 }
 
 // GetClusterName retrieves the cluster name from Istio's CLUSTER_ID environment variable in istiod deployment.

--- a/edge/pkg/kubernetes/client.go
+++ b/edge/pkg/kubernetes/client.go
@@ -22,15 +22,15 @@ import (
 
 	istioclient "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
+	istioextlisters "istio.io/client-go/pkg/listers/extensions/v1alpha1"
 	istiov1alpha3listers "istio.io/client-go/pkg/listers/networking/v1alpha3"
 	istiov1beta1listers "istio.io/client-go/pkg/listers/networking/v1beta1"
-	istioextlisters "istio.io/client-go/pkg/listers/extensions/v1alpha1"
 	istioseclisters "istio.io/client-go/pkg/listers/security/v1beta1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	appsv1lister "k8s.io/client-go/listers/apps/v1"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	discoveryv1lister "k8s.io/client-go/listers/discovery/v1"
-	"k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -127,8 +127,6 @@ func NewClientWithContext(kubeconfigPath string, contextName string, logger *slo
 	}, nil
 }
 
-// Start initialises informer factories, starts all informers, and waits for cache sync.
-// Must be called before GetClusterState.
 // Start initialises informer factories, starts all informers, and waits for cache sync.
 // Must be called before GetClusterState.
 func (k *Client) Start(ctx context.Context) error {

--- a/edge/pkg/kubernetes/client.go
+++ b/edge/pkg/kubernetes/client.go
@@ -215,7 +215,7 @@ func (k *Client) GetRestConfig() *rest.Config {
 }
 
 // GetClusterName retrieves the cluster name from Istio's CLUSTER_ID environment variable in istiod deployment.
-// This uses direct API calls and must be called before Start.
+// This uses direct API calls and may be called before or after Start.
 func (k *Client) GetClusterName(ctx context.Context) (string, error) {
 	rootNamespace, activeDeployment := k.discoverIstioControlPlane(ctx)
 	if activeDeployment == nil {

--- a/edge/pkg/kubernetes/client_test.go
+++ b/edge/pkg/kubernetes/client_test.go
@@ -16,10 +16,8 @@ package kubernetes
 
 import (
 	"context"
-	"errors"
 	"testing"
 
-	"github.com/liamawhite/navigator/pkg/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	extensionsapi "istio.io/api/extensions/v1alpha1"
@@ -152,48 +150,6 @@ func TestClient_GetClusterState(t *testing.T) {
 				assert.NoError(t, err)
 				assert.NotNil(t, got)
 				assert.Len(t, got.Services, tt.wantServices)
-			}
-		})
-	}
-}
-
-func TestClient_mergeErrors(t *testing.T) {
-	client := &Client{logger: logging.For("test")}
-
-	tests := []struct {
-		name   string
-		errors []error
-		want   string
-	}{
-		{
-			name:   "no errors",
-			errors: nil,
-			want:   "",
-		},
-		{
-			name:   "single error",
-			errors: []error{errors.New("first error")},
-			want:   "first error",
-		},
-		{
-			name: "multiple errors",
-			errors: []error{
-				errors.New("first error"),
-				errors.New("second error"),
-				errors.New("third error"),
-			},
-			want: "multiple errors occurred (3 total): first error; second error; third error",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := client.mergeErrors(tt.errors)
-			if tt.want == "" {
-				assert.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				assert.Equal(t, tt.want, err.Error())
 			}
 		})
 	}

--- a/edge/pkg/kubernetes/client_test.go
+++ b/edge/pkg/kubernetes/client_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/liamawhite/navigator/pkg/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	extensionsapi "istio.io/api/extensions/v1alpha1"
@@ -250,4 +251,18 @@ func TestClient_GetClusterStateWithWasmPlugins(t *testing.T) {
 
 	assert.Len(t, result.RequestAuthentications, 1)
 	assert.Equal(t, "test-request-auth", result.RequestAuthentications[0].Name)
+}
+
+func TestClient_StartTwiceReturnsError(t *testing.T) {
+	c := newTestClient(t, nil, nil)
+	err := c.Start(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already started")
+}
+
+func TestClient_GetClusterStateBeforeStartReturnsError(t *testing.T) {
+	c := &Client{logger: logging.For("test")}
+	_, err := c.GetClusterState(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "call Start first")
 }

--- a/edge/pkg/kubernetes/client_test.go
+++ b/edge/pkg/kubernetes/client_test.go
@@ -29,11 +29,10 @@ import (
 	istioextensionsv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	istiosecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
-	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Helper function to create a bool pointer
@@ -132,27 +131,20 @@ func TestClient_GetClusterState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create fake clientset
-			clientset := fake.NewSimpleClientset()
-
-			// Add objects to fake clientset
-			for _, svc := range tt.services {
-				_, _ = clientset.CoreV1().Services(svc.Namespace).Create(context.TODO(), &svc, metav1.CreateOptions{})
+			var k8sObjects []runtime.Object
+			for i := range tt.services {
+				k8sObjects = append(k8sObjects, &tt.services[i])
 			}
-			for _, eps := range tt.endpointSlices {
-				_, _ = clientset.DiscoveryV1().EndpointSlices(eps.Namespace).Create(context.TODO(), &eps, metav1.CreateOptions{})
+			for i := range tt.endpointSlices {
+				k8sObjects = append(k8sObjects, &tt.endpointSlices[i])
 			}
-			for _, pod := range tt.pods {
-				_, _ = clientset.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
+			for i := range tt.pods {
+				k8sObjects = append(k8sObjects, &tt.pods[i])
 			}
 
-			k8sClient := &Client{
-				clientset:   clientset,
-				istioClient: istiofake.NewSimpleClientset(),
-				logger:      logging.For("test"),
-			}
+			client := newTestClient(t, k8sObjects, nil)
 
-			got, err := k8sClient.GetClusterState(context.TODO())
+			got, err := client.GetClusterState(context.TODO())
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -208,7 +200,6 @@ func TestClient_mergeErrors(t *testing.T) {
 }
 
 func TestClient_GetClusterStateWithIstio(t *testing.T) {
-	// Create test Kubernetes resources
 	service := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-service",
@@ -216,7 +207,6 @@ func TestClient_GetClusterStateWithIstio(t *testing.T) {
 		},
 	}
 
-	// Create test Istio resources
 	dr := &istionetworkingv1beta1.DestinationRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-dr",
@@ -227,33 +217,25 @@ func TestClient_GetClusterStateWithIstio(t *testing.T) {
 		},
 	}
 
-	// Create fake clients
-	k8sClient := fake.NewSimpleClientset(&service)
-	istioClient := istiofake.NewSimpleClientset(dr)
-
-	client := &Client{
-		clientset:   k8sClient,
-		istioClient: istioClient,
-		logger:      logging.For("test"),
-	}
+	client := newTestClient(t,
+		[]runtime.Object{&service},
+		[]runtime.Object{dr},
+	)
 
 	result, err := client.GetClusterState(context.Background())
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// Verify Kubernetes resources
 	assert.Len(t, result.Services, 1)
 	assert.Equal(t, "test-service", result.Services[0].Name)
 
-	// Verify Istio resources
 	assert.Len(t, result.DestinationRules, 1)
 	assert.Equal(t, "test-dr", result.DestinationRules[0].Name)
 	assert.Contains(t, result.DestinationRules[0].RawConfig, "test-service")
 }
 
 func TestClient_GetClusterStateWithWasmPlugins(t *testing.T) {
-	// Create test Kubernetes resources
 	service := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-service",
@@ -261,7 +243,6 @@ func TestClient_GetClusterStateWithWasmPlugins(t *testing.T) {
 		},
 	}
 
-	// Create test WasmPlugin
 	wasmPlugin := &istioextensionsv1alpha1.WasmPlugin{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-wasm-plugin",
@@ -277,7 +258,6 @@ func TestClient_GetClusterStateWithWasmPlugins(t *testing.T) {
 		},
 	}
 
-	// Create test RequestAuthentication for comparison
 	requestAuth := &istiosecurityv1beta1.RequestAuthentication{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-request-auth",
@@ -292,26 +272,19 @@ func TestClient_GetClusterStateWithWasmPlugins(t *testing.T) {
 		},
 	}
 
-	// Create fake clients
-	k8sClient := fake.NewSimpleClientset(&service)
-	istioClient := istiofake.NewSimpleClientset(wasmPlugin, requestAuth)
-
-	client := &Client{
-		clientset:   k8sClient,
-		istioClient: istioClient,
-		logger:      logging.For("test"),
-	}
+	client := newTestClient(t,
+		[]runtime.Object{&service},
+		[]runtime.Object{wasmPlugin, requestAuth},
+	)
 
 	result, err := client.GetClusterState(context.Background())
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// Verify Kubernetes resources
 	assert.Len(t, result.Services, 1)
 	assert.Equal(t, "test-service", result.Services[0].Name)
 
-	// Verify WasmPlugin resources
 	assert.Len(t, result.WasmPlugins, 1)
 	assert.Equal(t, "test-wasm-plugin", result.WasmPlugins[0].Name)
 	assert.Equal(t, "default", result.WasmPlugins[0].Namespace)
@@ -319,7 +292,6 @@ func TestClient_GetClusterStateWithWasmPlugins(t *testing.T) {
 	assert.Equal(t, "test-service", result.WasmPlugins[0].Selector.MatchLabels["app"])
 	assert.Contains(t, result.WasmPlugins[0].RawConfig, "oci://docker.io/istio/test-plugin:latest")
 
-	// Verify RequestAuthentication is still working (regression test)
 	assert.Len(t, result.RequestAuthentications, 1)
 	assert.Equal(t, "test-request-auth", result.RequestAuthentications[0].Name)
 }

--- a/edge/pkg/kubernetes/istio.go
+++ b/edge/pkg/kubernetes/istio.go
@@ -247,7 +247,7 @@ func (k *Client) getIstioControlPlaneConfig() *typesv1alpha1.IstioControlPlaneCo
 
 	// Prefer istio-system namespace
 	if deps, ok := byNamespace["istio-system"]; ok {
-		active := k.selectActiveControlPlane(derefDeployments(deps))
+		active := k.selectActiveControlPlane(deps)
 		if active != nil {
 			config.RootNamespace = "istio-system"
 			k.logger.Debug("selected active istiod deployment", "name", active.Name, "namespace", active.Namespace)
@@ -261,7 +261,7 @@ func (k *Client) getIstioControlPlaneConfig() *typesv1alpha1.IstioControlPlaneCo
 	var bestNS string
 	maxReady := int32(-1)
 	for ns, deps := range byNamespace {
-		active := k.selectActiveControlPlane(derefDeployments(deps))
+		active := k.selectActiveControlPlane(deps)
 		if active != nil && active.Status.ReadyReplicas > maxReady {
 			maxReady = active.Status.ReadyReplicas
 			bestDep = active
@@ -317,7 +317,11 @@ func (k *Client) discoverIstioControlPlane(ctx context.Context) (string, *appsv1
 			continue
 		}
 
-		activeDeployment := k.selectActiveControlPlane(deployments.Items)
+		depPtrs := make([]*appsv1.Deployment, len(deployments.Items))
+		for i := range deployments.Items {
+			depPtrs[i] = &deployments.Items[i]
+		}
+		activeDeployment := k.selectActiveControlPlane(depPtrs)
 		if activeDeployment == nil {
 			continue
 		}
@@ -351,16 +355,16 @@ func (k *Client) discoverIstioControlPlane(ctx context.Context) (string, *appsv1
 // 1. Deployment named "istiod" (traditional default)
 // 2. Deployment with highest ready replicas
 // 3. First deployment (fallback)
-func (k *Client) selectActiveControlPlane(deployments []appsv1.Deployment) *appsv1.Deployment {
+func (k *Client) selectActiveControlPlane(deployments []*appsv1.Deployment) *appsv1.Deployment {
 	if len(deployments) == 0 {
 		return nil
 	}
 
 	// Priority 1: Look for traditional "istiod" deployment
-	for i := range deployments {
-		if deployments[i].Name == "istiod" {
+	for _, d := range deployments {
+		if d.Name == "istiod" {
 			k.logger.Debug("found traditional istiod deployment")
-			return &deployments[i]
+			return d
 		}
 	}
 
@@ -368,13 +372,10 @@ func (k *Client) selectActiveControlPlane(deployments []appsv1.Deployment) *apps
 	var bestDeployment *appsv1.Deployment
 	maxReadyReplicas := int32(-1)
 
-	for i := range deployments {
-		deployment := &deployments[i]
-		readyReplicas := deployment.Status.ReadyReplicas
-
-		if readyReplicas > maxReadyReplicas {
-			maxReadyReplicas = readyReplicas
-			bestDeployment = deployment
+	for _, d := range deployments {
+		if d.Status.ReadyReplicas > maxReadyReplicas {
+			maxReadyReplicas = d.Status.ReadyReplicas
+			bestDeployment = d
 		}
 	}
 
@@ -387,7 +388,7 @@ func (k *Client) selectActiveControlPlane(deployments []appsv1.Deployment) *apps
 
 	// Priority 3: Fallback to first deployment
 	k.logger.Debug("using first available deployment as fallback", "name", deployments[0].Name)
-	return &deployments[0]
+	return deployments[0]
 }
 
 // extractPilotConfiguration extracts pilot configuration from an istiod deployment
@@ -766,13 +767,4 @@ func (k *Client) convertServiceEntry(se *istionetworkingv1beta1.ServiceEntry) (*
 		RawConfig: string(resourceBytes),
 		ExportTo:  exportTo,
 	}, nil
-}
-
-// derefDeployments converts a slice of Deployment pointers to values
-func derefDeployments(ptrs []*appsv1.Deployment) []appsv1.Deployment {
-	out := make([]appsv1.Deployment, len(ptrs))
-	for i, p := range ptrs {
-		out[i] = *p
-	}
-	return out
 }

--- a/edge/pkg/kubernetes/istio.go
+++ b/edge/pkg/kubernetes/istio.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
 
 	typesv1alpha1 "github.com/liamawhite/navigator/pkg/api/types/v1alpha1"
 	istioextensionsv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
@@ -27,620 +26,261 @@ import (
 	istiosecurityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
-// fetchDestinationRules fetches and converts all destination rules from the cluster
-func (k *Client) fetchDestinationRules(ctx context.Context, wg *sync.WaitGroup, result *[]*typesv1alpha1.DestinationRule, errChan chan<- error) {
-	defer wg.Done()
-	drList, err := k.istioClient.NetworkingV1beta1().DestinationRules("").List(ctx, metav1.ListOptions{})
+// listDestinationRules reads DestinationRules from the informer cache and converts them.
+func (k *Client) listDestinationRules() []*typesv1alpha1.DestinationRule {
+	items, err := k.destinationRulesLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list destination rules: %w", err)
-		return
+		k.logger.Error("failed to list destination rules from cache", "error", err)
+		return nil
 	}
-
-	var protoDestinationRules []*typesv1alpha1.DestinationRule
-	for i := range drList.Items {
-		dr := drList.Items[i]
-		protoDR, convertErr := k.convertDestinationRule(dr)
-		if convertErr != nil {
-			k.logger.Warn("failed to convert destination rule", "name", dr.Name, "namespace", dr.Namespace, "error", convertErr)
+	var result []*typesv1alpha1.DestinationRule
+	for _, dr := range items {
+		proto, err := k.convertDestinationRule(dr)
+		if err != nil {
+			k.logger.Warn("failed to convert destination rule", "name", dr.Name, "namespace", dr.Namespace, "error", err)
 			continue
 		}
-		protoDestinationRules = append(protoDestinationRules, protoDR)
+		result = append(result, proto)
 	}
-	*result = protoDestinationRules
+	return result
 }
 
-// fetchEnvoyFilters fetches and converts all envoy filters from the cluster
-func (k *Client) fetchEnvoyFilters(ctx context.Context, wg *sync.WaitGroup, result *[]*typesv1alpha1.EnvoyFilter, errChan chan<- error) {
-	defer wg.Done()
-	efList, err := k.istioClient.NetworkingV1alpha3().EnvoyFilters("").List(ctx, metav1.ListOptions{})
+// listEnvoyFilters reads EnvoyFilters from the informer cache and converts them.
+func (k *Client) listEnvoyFilters() []*typesv1alpha1.EnvoyFilter {
+	items, err := k.envoyFiltersLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list envoy filters: %w", err)
-		return
+		k.logger.Error("failed to list envoy filters from cache", "error", err)
+		return nil
 	}
-
-	var protoEnvoyFilters []*typesv1alpha1.EnvoyFilter
-	for i := range efList.Items {
-		ef := efList.Items[i]
-		protoEF, convertErr := k.convertEnvoyFilter(ef)
-		if convertErr != nil {
-			k.logger.Warn("failed to convert envoy filter", "name", ef.Name, "namespace", ef.Namespace, "error", convertErr)
+	var result []*typesv1alpha1.EnvoyFilter
+	for _, ef := range items {
+		proto, err := k.convertEnvoyFilter(ef)
+		if err != nil {
+			k.logger.Warn("failed to convert envoy filter", "name", ef.Name, "namespace", ef.Namespace, "error", err)
 			continue
 		}
-		protoEnvoyFilters = append(protoEnvoyFilters, protoEF)
+		result = append(result, proto)
 	}
-	*result = protoEnvoyFilters
+	return result
 }
 
-// fetchRequestAuthentications fetches and converts all request authentications from the cluster
-func (k *Client) fetchRequestAuthentications(ctx context.Context, wg *sync.WaitGroup, result *[]*typesv1alpha1.RequestAuthentication, errChan chan<- error) {
-	defer wg.Done()
-	raList, err := k.istioClient.SecurityV1beta1().RequestAuthentications("").List(ctx, metav1.ListOptions{})
+// listRequestAuthentications reads RequestAuthentications from the informer cache and converts them.
+func (k *Client) listRequestAuthentications() []*typesv1alpha1.RequestAuthentication {
+	items, err := k.requestAuthenticationsLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list request authentications: %w", err)
-		return
+		k.logger.Error("failed to list request authentications from cache", "error", err)
+		return nil
 	}
-
-	var protoRequestAuthentications []*typesv1alpha1.RequestAuthentication
-	for i := range raList.Items {
-		ra := raList.Items[i]
-		protoRA, convertErr := k.convertRequestAuthentication(ra)
-		if convertErr != nil {
-			k.logger.Warn("failed to convert request authentication", "name", ra.Name, "namespace", ra.Namespace, "error", convertErr)
+	var result []*typesv1alpha1.RequestAuthentication
+	for _, ra := range items {
+		proto, err := k.convertRequestAuthentication(ra)
+		if err != nil {
+			k.logger.Warn("failed to convert request authentication", "name", ra.Name, "namespace", ra.Namespace, "error", err)
 			continue
 		}
-		protoRequestAuthentications = append(protoRequestAuthentications, protoRA)
+		result = append(result, proto)
 	}
-	*result = protoRequestAuthentications
+	return result
 }
 
-// fetchPeerAuthentications fetches and converts all peer authentications from the cluster
-func (k *Client) fetchPeerAuthentications(ctx context.Context, wg *sync.WaitGroup, result *[]*typesv1alpha1.PeerAuthentication, errChan chan<- error) {
-	defer wg.Done()
-	paList, err := k.istioClient.SecurityV1beta1().PeerAuthentications("").List(ctx, metav1.ListOptions{})
+// listPeerAuthentications reads PeerAuthentications from the informer cache and converts them.
+func (k *Client) listPeerAuthentications() []*typesv1alpha1.PeerAuthentication {
+	items, err := k.peerAuthenticationsLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list peer authentications: %w", err)
-		return
+		k.logger.Error("failed to list peer authentications from cache", "error", err)
+		return nil
 	}
-
-	var protoPeerAuthentications []*typesv1alpha1.PeerAuthentication
-	for i := range paList.Items {
-		pa := paList.Items[i]
-		protoPA, convertErr := k.convertPeerAuthentication(pa)
-		if convertErr != nil {
-			k.logger.Warn("failed to convert peer authentication", "name", pa.Name, "namespace", pa.Namespace, "error", convertErr)
+	var result []*typesv1alpha1.PeerAuthentication
+	for _, pa := range items {
+		proto, err := k.convertPeerAuthentication(pa)
+		if err != nil {
+			k.logger.Warn("failed to convert peer authentication", "name", pa.Name, "namespace", pa.Namespace, "error", err)
 			continue
 		}
-		protoPeerAuthentications = append(protoPeerAuthentications, protoPA)
+		result = append(result, proto)
 	}
-	*result = protoPeerAuthentications
+	return result
 }
 
-// fetchAuthorizationPolicies fetches and converts all authorization policies from the cluster
-func (k *Client) fetchAuthorizationPolicies(ctx context.Context, wg *sync.WaitGroup, result *[]*typesv1alpha1.AuthorizationPolicy, errChan chan<- error) {
-	defer wg.Done()
-	apList, err := k.istioClient.SecurityV1beta1().AuthorizationPolicies("").List(ctx, metav1.ListOptions{})
+// listAuthorizationPolicies reads AuthorizationPolicies from the informer cache and converts them.
+func (k *Client) listAuthorizationPolicies() []*typesv1alpha1.AuthorizationPolicy {
+	items, err := k.authorizationPoliciesLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list authorization policies: %w", err)
-		return
+		k.logger.Error("failed to list authorization policies from cache", "error", err)
+		return nil
 	}
-
-	var protoAuthorizationPolicies []*typesv1alpha1.AuthorizationPolicy
-	for i := range apList.Items {
-		ap := apList.Items[i]
-		protoAP, convertErr := k.convertAuthorizationPolicy(ap)
-		if convertErr != nil {
-			k.logger.Warn("failed to convert authorization policy", "name", ap.Name, "namespace", ap.Namespace, "error", convertErr)
+	var result []*typesv1alpha1.AuthorizationPolicy
+	for _, ap := range items {
+		proto, err := k.convertAuthorizationPolicy(ap)
+		if err != nil {
+			k.logger.Warn("failed to convert authorization policy", "name", ap.Name, "namespace", ap.Namespace, "error", err)
 			continue
 		}
-		protoAuthorizationPolicies = append(protoAuthorizationPolicies, protoAP)
+		result = append(result, proto)
 	}
-	*result = protoAuthorizationPolicies
+	return result
 }
 
-// fetchWasmPlugins fetches and converts all wasm plugins from the cluster
-func (k *Client) fetchWasmPlugins(ctx context.Context, wg *sync.WaitGroup, result *[]*typesv1alpha1.WasmPlugin, errChan chan<- error) {
-	defer wg.Done()
-	wpList, err := k.istioClient.ExtensionsV1alpha1().WasmPlugins("").List(ctx, metav1.ListOptions{})
+// listWasmPlugins reads WasmPlugins from the informer cache and converts them.
+func (k *Client) listWasmPlugins() []*typesv1alpha1.WasmPlugin {
+	items, err := k.wasmPluginsLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list wasm plugins: %w", err)
-		return
+		k.logger.Error("failed to list wasm plugins from cache", "error", err)
+		return nil
 	}
-
-	var protoWasmPlugins []*typesv1alpha1.WasmPlugin
-	for i := range wpList.Items {
-		wp := wpList.Items[i]
-		protoWP, convertErr := k.convertWasmPlugin(wp)
-		if convertErr != nil {
-			k.logger.Warn("failed to convert wasm plugin", "name", wp.Name, "namespace", wp.Namespace, "error", convertErr)
+	var result []*typesv1alpha1.WasmPlugin
+	for _, wp := range items {
+		proto, err := k.convertWasmPlugin(wp)
+		if err != nil {
+			k.logger.Warn("failed to convert wasm plugin", "name", wp.Name, "namespace", wp.Namespace, "error", err)
 			continue
 		}
-		protoWasmPlugins = append(protoWasmPlugins, protoWP)
+		result = append(result, proto)
 	}
-	*result = protoWasmPlugins
+	return result
 }
 
-// fetchGateways fetches and converts all gateways from the cluster
-func (k *Client) fetchGateways(ctx context.Context, wg *sync.WaitGroup, result *[]*typesv1alpha1.Gateway, errChan chan<- error) {
-	defer wg.Done()
-	gwList, err := k.istioClient.NetworkingV1beta1().Gateways("").List(ctx, metav1.ListOptions{})
+// listGateways reads Gateways from the informer cache and converts them.
+func (k *Client) listGateways() []*typesv1alpha1.Gateway {
+	items, err := k.gatewaysLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list gateways: %w", err)
-		return
+		k.logger.Error("failed to list gateways from cache", "error", err)
+		return nil
 	}
-
-	var protoGateways []*typesv1alpha1.Gateway
-	for i := range gwList.Items {
-		gw := gwList.Items[i]
-		protoGW, convertErr := k.convertGateway(gw)
-		if convertErr != nil {
-			k.logger.Warn("failed to convert gateway", "name", gw.Name, "namespace", gw.Namespace, "error", convertErr)
+	var result []*typesv1alpha1.Gateway
+	for _, gw := range items {
+		proto, err := k.convertGateway(gw)
+		if err != nil {
+			k.logger.Warn("failed to convert gateway", "name", gw.Name, "namespace", gw.Namespace, "error", err)
 			continue
 		}
-		protoGateways = append(protoGateways, protoGW)
+		result = append(result, proto)
 	}
-	*result = protoGateways
+	return result
 }
 
-// fetchSidecars fetches and converts all sidecars from the cluster
-func (k *Client) fetchSidecars(ctx context.Context, wg *sync.WaitGroup, result *[]*typesv1alpha1.Sidecar, errChan chan<- error) {
-	defer wg.Done()
-	scList, err := k.istioClient.NetworkingV1beta1().Sidecars("").List(ctx, metav1.ListOptions{})
+// listSidecars reads Sidecars from the informer cache and converts them.
+func (k *Client) listSidecars() []*typesv1alpha1.Sidecar {
+	items, err := k.sidecarsLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list sidecars: %w", err)
-		return
+		k.logger.Error("failed to list sidecars from cache", "error", err)
+		return nil
 	}
-
-	var protoSidecars []*typesv1alpha1.Sidecar
-	for i := range scList.Items {
-		sc := scList.Items[i]
-		protoSC, convertErr := k.convertSidecar(sc)
-		if convertErr != nil {
-			k.logger.Warn("failed to convert sidecar", "name", sc.Name, "namespace", sc.Namespace, "error", convertErr)
+	var result []*typesv1alpha1.Sidecar
+	for _, sc := range items {
+		proto, err := k.convertSidecar(sc)
+		if err != nil {
+			k.logger.Warn("failed to convert sidecar", "name", sc.Name, "namespace", sc.Namespace, "error", err)
 			continue
 		}
-		protoSidecars = append(protoSidecars, protoSC)
+		result = append(result, proto)
 	}
-	*result = protoSidecars
+	return result
 }
 
-// fetchVirtualServices fetches and converts all virtual services from the cluster
-func (k *Client) fetchVirtualServices(ctx context.Context, wg *sync.WaitGroup, result *[]*typesv1alpha1.VirtualService, errChan chan<- error) {
-	defer wg.Done()
-	vsList, err := k.istioClient.NetworkingV1beta1().VirtualServices("").List(ctx, metav1.ListOptions{})
+// listVirtualServices reads VirtualServices from the informer cache and converts them.
+func (k *Client) listVirtualServices() []*typesv1alpha1.VirtualService {
+	items, err := k.virtualServicesLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list virtual services: %w", err)
-		return
+		k.logger.Error("failed to list virtual services from cache", "error", err)
+		return nil
 	}
-
-	var protoVirtualServices []*typesv1alpha1.VirtualService
-	for i := range vsList.Items {
-		vs := vsList.Items[i]
-		protoVS, convertErr := k.convertVirtualService(vs)
-		if convertErr != nil {
-			k.logger.Warn("failed to convert virtual service", "name", vs.Name, "namespace", vs.Namespace, "error", convertErr)
+	var result []*typesv1alpha1.VirtualService
+	for _, vs := range items {
+		proto, err := k.convertVirtualService(vs)
+		if err != nil {
+			k.logger.Warn("failed to convert virtual service", "name", vs.Name, "namespace", vs.Namespace, "error", err)
 			continue
 		}
-		protoVirtualServices = append(protoVirtualServices, protoVS)
+		result = append(result, proto)
 	}
-	*result = protoVirtualServices
+	return result
 }
 
-// fetchServiceEntries fetches and converts all service entries from the cluster
-func (k *Client) fetchServiceEntries(ctx context.Context, wg *sync.WaitGroup, result *[]*typesv1alpha1.ServiceEntry, errChan chan<- error) {
-	defer wg.Done()
-	seList, err := k.istioClient.NetworkingV1beta1().ServiceEntries("").List(ctx, metav1.ListOptions{})
+// listServiceEntries reads ServiceEntries from the informer cache and converts them.
+func (k *Client) listServiceEntries() []*typesv1alpha1.ServiceEntry {
+	items, err := k.serviceEntriesLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list service entries: %w", err)
-		return
+		k.logger.Error("failed to list service entries from cache", "error", err)
+		return nil
 	}
-
-	var protoServiceEntries []*typesv1alpha1.ServiceEntry
-	for i := range seList.Items {
-		se := seList.Items[i]
-		protoSE, convertErr := k.convertServiceEntry(se)
-		if convertErr != nil {
-			k.logger.Warn("failed to convert service entry", "name", se.Name, "namespace", se.Namespace, "error", convertErr)
+	var result []*typesv1alpha1.ServiceEntry
+	for _, se := range items {
+		proto, err := k.convertServiceEntry(se)
+		if err != nil {
+			k.logger.Warn("failed to convert service entry", "name", se.Name, "namespace", se.Namespace, "error", err)
 			continue
 		}
-		protoServiceEntries = append(protoServiceEntries, protoSE)
+		result = append(result, proto)
 	}
-	*result = protoServiceEntries
+	return result
 }
 
-// convertDestinationRule converts an Istio DestinationRule to a protobuf DestinationRule
-func (k *Client) convertDestinationRule(dr *istionetworkingv1beta1.DestinationRule) (*typesv1alpha1.DestinationRule, error) {
-	resourceBytes, err := json.Marshal(dr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal destination rule resource: %w", err)
-	}
-
-	// Extract host from the spec
-	var host string
-	if dr.Spec.Host != "" {
-		host = dr.Spec.Host
-	}
-
-	// Extract subsets from the spec
-	var subsets []*typesv1alpha1.DestinationRuleSubset
-	for _, subset := range dr.Spec.Subsets {
-		protoSubset := &typesv1alpha1.DestinationRuleSubset{
-			Name:   subset.Name,
-			Labels: make(map[string]string),
-		}
-		if subset.Labels != nil {
-			for key, value := range subset.Labels {
-				protoSubset.Labels[key] = value
-			}
-		}
-		subsets = append(subsets, protoSubset)
-	}
-
-	// Default for exportTo is ["*"] if not specified or empty
-	var exportTo []string
-	if len(dr.Spec.ExportTo) > 0 {
-		exportTo = dr.Spec.ExportTo
-	} else {
-		exportTo = []string{"*"}
-	}
-
-	// Extract workload selector from the spec
-	var workloadSelector *typesv1alpha1.WorkloadSelector
-	if dr.Spec.WorkloadSelector != nil && dr.Spec.WorkloadSelector.MatchLabels != nil {
-		matchLabels := make(map[string]string)
-		for key, value := range dr.Spec.WorkloadSelector.MatchLabels {
-			matchLabels[key] = value
-		}
-		workloadSelector = &typesv1alpha1.WorkloadSelector{
-			MatchLabels: matchLabels,
-		}
-	}
-
-	return &typesv1alpha1.DestinationRule{
-		Name:             dr.Name,
-		Namespace:        dr.Namespace,
-		RawConfig:        string(resourceBytes),
-		Host:             host,
-		Subsets:          subsets,
-		ExportTo:         exportTo,
-		WorkloadSelector: workloadSelector,
-	}, nil
-}
-
-// convertEnvoyFilter converts an Istio EnvoyFilter to a protobuf EnvoyFilter
-func (k *Client) convertEnvoyFilter(ef *istionetworkingv1alpha3.EnvoyFilter) (*typesv1alpha1.EnvoyFilter, error) {
-	resourceBytes, err := json.Marshal(ef)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal envoy filter resource: %w", err)
-	}
-
-	// Extract workload selector from the spec
-	var workloadSelector *typesv1alpha1.WorkloadSelector
-	if ef.Spec.WorkloadSelector != nil && ef.Spec.WorkloadSelector.Labels != nil {
-		matchLabels := make(map[string]string)
-		for key, value := range ef.Spec.WorkloadSelector.Labels {
-			matchLabels[key] = value
-		}
-		workloadSelector = &typesv1alpha1.WorkloadSelector{
-			MatchLabels: matchLabels,
-		}
-	}
-
-	// Extract target refs from the spec
-	var targetRefs []*typesv1alpha1.PolicyTargetReference
-	for _, targetRef := range ef.Spec.TargetRefs {
-		if targetRef != nil {
-			protoTargetRef := &typesv1alpha1.PolicyTargetReference{
-				Group:     targetRef.Group,
-				Kind:      targetRef.Kind,
-				Name:      targetRef.Name,
-				Namespace: targetRef.Namespace,
-			}
-			targetRefs = append(targetRefs, protoTargetRef)
-		}
-	}
-
-	return &typesv1alpha1.EnvoyFilter{
-		Name:             ef.Name,
-		Namespace:        ef.Namespace,
-		RawConfig:        string(resourceBytes),
-		WorkloadSelector: workloadSelector,
-		TargetRefs:       targetRefs,
-	}, nil
-}
-
-// convertRequestAuthentication converts an Istio RequestAuthentication to a protobuf RequestAuthentication
-func (k *Client) convertRequestAuthentication(ra *istiosecurityv1beta1.RequestAuthentication) (*typesv1alpha1.RequestAuthentication, error) {
-	resourceBytes, err := json.Marshal(ra)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request authentication resource: %w", err)
-	}
-
-	// Extract selector from the spec
-	var selector *typesv1alpha1.WorkloadSelector
-	if ra.Spec.Selector != nil && ra.Spec.Selector.MatchLabels != nil {
-		matchLabels := make(map[string]string)
-		for key, value := range ra.Spec.Selector.MatchLabels {
-			matchLabels[key] = value
-		}
-		selector = &typesv1alpha1.WorkloadSelector{
-			MatchLabels: matchLabels,
-		}
-	}
-
-	// Extract target refs from the spec
-	var targetRefs []*typesv1alpha1.PolicyTargetReference
-	for _, targetRef := range ra.Spec.TargetRefs {
-		if targetRef != nil {
-			protoTargetRef := &typesv1alpha1.PolicyTargetReference{
-				Group:     targetRef.Group,
-				Kind:      targetRef.Kind,
-				Name:      targetRef.Name,
-				Namespace: targetRef.Namespace,
-			}
-			targetRefs = append(targetRefs, protoTargetRef)
-		}
-	}
-
-	return &typesv1alpha1.RequestAuthentication{
-		Name:       ra.Name,
-		Namespace:  ra.Namespace,
-		RawConfig:  string(resourceBytes),
-		Selector:   selector,
-		TargetRefs: targetRefs,
-	}, nil
-}
-
-// convertPeerAuthentication converts an Istio PeerAuthentication to a protobuf PeerAuthentication
-func (k *Client) convertPeerAuthentication(pa *istiosecurityv1beta1.PeerAuthentication) (*typesv1alpha1.PeerAuthentication, error) {
-	resourceBytes, err := json.Marshal(pa)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal peer authentication resource: %w", err)
-	}
-
-	// Extract selector from the spec
-	var selector *typesv1alpha1.WorkloadSelector
-	if pa.Spec.Selector != nil && pa.Spec.Selector.MatchLabels != nil {
-		matchLabels := make(map[string]string)
-		for key, value := range pa.Spec.Selector.MatchLabels {
-			matchLabels[key] = value
-		}
-		selector = &typesv1alpha1.WorkloadSelector{
-			MatchLabels: matchLabels,
-		}
-	}
-
-	return &typesv1alpha1.PeerAuthentication{
-		Name:      pa.Name,
-		Namespace: pa.Namespace,
-		RawConfig: string(resourceBytes),
-		Selector:  selector,
-	}, nil
-}
-
-// convertAuthorizationPolicy converts an Istio AuthorizationPolicy to a protobuf AuthorizationPolicy
-func (k *Client) convertAuthorizationPolicy(ap *istiosecurityv1beta1.AuthorizationPolicy) (*typesv1alpha1.AuthorizationPolicy, error) {
-	resourceBytes, err := json.Marshal(ap)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal authorization policy resource: %w", err)
-	}
-
-	// Extract selector from the spec
-	var selector *typesv1alpha1.WorkloadSelector
-	if ap.Spec.Selector != nil && ap.Spec.Selector.MatchLabels != nil {
-		matchLabels := make(map[string]string)
-		for key, value := range ap.Spec.Selector.MatchLabels {
-			matchLabels[key] = value
-		}
-		selector = &typesv1alpha1.WorkloadSelector{
-			MatchLabels: matchLabels,
-		}
-	}
-
-	// Extract target refs from the spec
-	var targetRefs []*typesv1alpha1.PolicyTargetReference
-
-	// Handle TargetRef (singular) - older API
-	if ap.Spec.TargetRef != nil {
-		protoTargetRef := &typesv1alpha1.PolicyTargetReference{
-			Group:     ap.Spec.TargetRef.Group,
-			Kind:      ap.Spec.TargetRef.Kind,
-			Name:      ap.Spec.TargetRef.Name,
-			Namespace: ap.Spec.TargetRef.Namespace,
-		}
-		targetRefs = append(targetRefs, protoTargetRef)
-	}
-
-	// Handle TargetRefs (plural) - newer API
-	for _, targetRef := range ap.Spec.TargetRefs {
-		if targetRef != nil {
-			protoTargetRef := &typesv1alpha1.PolicyTargetReference{
-				Group:     targetRef.Group,
-				Kind:      targetRef.Kind,
-				Name:      targetRef.Name,
-				Namespace: targetRef.Namespace,
-			}
-			targetRefs = append(targetRefs, protoTargetRef)
-		}
-	}
-
-	return &typesv1alpha1.AuthorizationPolicy{
-		Name:       ap.Name,
-		Namespace:  ap.Namespace,
-		RawConfig:  string(resourceBytes),
-		Selector:   selector,
-		TargetRefs: targetRefs,
-	}, nil
-}
-
-// convertWasmPlugin converts an Istio WasmPlugin to a protobuf WasmPlugin
-func (k *Client) convertWasmPlugin(wp *istioextensionsv1alpha1.WasmPlugin) (*typesv1alpha1.WasmPlugin, error) {
-	resourceBytes, err := json.Marshal(wp)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal wasm plugin resource: %w", err)
-	}
-
-	// Extract selector from the spec
-	var selector *typesv1alpha1.WorkloadSelector
-	if wp.Spec.Selector != nil && wp.Spec.Selector.MatchLabels != nil {
-		matchLabels := make(map[string]string)
-		for key, value := range wp.Spec.Selector.MatchLabels {
-			matchLabels[key] = value
-		}
-		selector = &typesv1alpha1.WorkloadSelector{
-			MatchLabels: matchLabels,
-		}
-	}
-
-	// Extract target refs from the spec
-	var targetRefs []*typesv1alpha1.PolicyTargetReference
-	for _, targetRef := range wp.Spec.TargetRefs {
-		if targetRef != nil {
-			protoTargetRef := &typesv1alpha1.PolicyTargetReference{
-				Group:     targetRef.Group,
-				Kind:      targetRef.Kind,
-				Name:      targetRef.Name,
-				Namespace: targetRef.Namespace,
-			}
-			targetRefs = append(targetRefs, protoTargetRef)
-		}
-	}
-
-	return &typesv1alpha1.WasmPlugin{
-		Name:       wp.Name,
-		Namespace:  wp.Namespace,
-		RawConfig:  string(resourceBytes),
-		Selector:   selector,
-		TargetRefs: targetRefs,
-	}, nil
-}
-
-// convertGateway converts an Istio Gateway to a protobuf Gateway
-func (k *Client) convertGateway(gw *istionetworkingv1beta1.Gateway) (*typesv1alpha1.Gateway, error) {
-	resourceBytes, err := json.Marshal(gw)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal gateway resource: %w", err)
-	}
-
-	// Extract selector from gateway spec
-	selector := make(map[string]string)
-	if gw.Spec.Selector != nil {
-		for key, value := range gw.Spec.Selector {
-			selector[key] = value
-		}
-	}
-
-	return &typesv1alpha1.Gateway{
-		Name:      gw.Name,
-		Namespace: gw.Namespace,
-		RawConfig: string(resourceBytes),
-		Selector:  selector,
-	}, nil
-}
-
-// convertSidecar converts an Istio Sidecar to a protobuf Sidecar
-func (k *Client) convertSidecar(sc *istionetworkingv1beta1.Sidecar) (*typesv1alpha1.Sidecar, error) {
-	resourceBytes, err := json.Marshal(sc)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal sidecar resource: %w", err)
-	}
-
-	// Extract workload selector from the spec
-	var workloadSelector *typesv1alpha1.WorkloadSelector
-	if sc.Spec.WorkloadSelector != nil && sc.Spec.WorkloadSelector.Labels != nil {
-		matchLabels := make(map[string]string)
-		for key, value := range sc.Spec.WorkloadSelector.Labels {
-			matchLabels[key] = value
-		}
-		workloadSelector = &typesv1alpha1.WorkloadSelector{
-			MatchLabels: matchLabels,
-		}
-	}
-
-	return &typesv1alpha1.Sidecar{
-		Name:             sc.Name,
-		Namespace:        sc.Namespace,
-		RawConfig:        string(resourceBytes),
-		WorkloadSelector: workloadSelector,
-	}, nil
-}
-
-// convertVirtualService converts an Istio VirtualService to a protobuf VirtualService
-func (k *Client) convertVirtualService(vs *istionetworkingv1beta1.VirtualService) (*typesv1alpha1.VirtualService, error) {
-	resourceBytes, err := json.Marshal(vs)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal virtual service resource: %w", err)
-	}
-
-	// Extract hosts, gateways, and exportTo from the spec
-	var hosts []string
-	if vs.Spec.Hosts != nil {
-		hosts = vs.Spec.Hosts
-	}
-
-	// Default for gateways is ["mesh"] if not specified or empty
-	var gateways []string
-	if len(vs.Spec.Gateways) > 0 {
-		gateways = vs.Spec.Gateways
-	} else {
-		gateways = []string{"mesh"}
-	}
-
-	// Default for exportTo is ["*"] if not specified or empty
-	var exportTo []string
-	if len(vs.Spec.ExportTo) > 0 {
-		exportTo = vs.Spec.ExportTo
-	} else {
-		exportTo = []string{"*"}
-	}
-
-	return &typesv1alpha1.VirtualService{
-		Name:      vs.Name,
-		Namespace: vs.Namespace,
-		RawConfig: string(resourceBytes),
-		Hosts:     hosts,
-		Gateways:  gateways,
-		ExportTo:  exportTo,
-	}, nil
-}
-
-// fetchIstioControlPlaneConfig fetches Istio control plane configuration.
-// Supports canary upgrades and revision-based Istio installations by discovering
-// all istiod deployments and selecting the active control plane.
-func (k *Client) fetchIstioControlPlaneConfig(ctx context.Context, wg *sync.WaitGroup, result **typesv1alpha1.IstioControlPlaneConfig, errChan chan<- error) {
-	defer wg.Done()
-
+// getIstioControlPlaneConfig reads Istio control plane config from the informer cache.
+func (k *Client) getIstioControlPlaneConfig() *typesv1alpha1.IstioControlPlaneConfig {
 	config := &typesv1alpha1.IstioControlPlaneConfig{
-		PilotScopeGatewayToNamespace: false,          // default value
-		RootNamespace:                "istio-system", // default fallback
+		PilotScopeGatewayToNamespace: false,
+		RootNamespace:                "istio-system",
 	}
 
-	// First, try to find the root namespace by searching across multiple common namespaces
-	rootNamespace, activeDeployment := k.discoverIstioControlPlane(ctx)
-	if rootNamespace != "" {
-		config.RootNamespace = rootNamespace
-		k.logger.Debug("discovered Istio root namespace", "namespace", rootNamespace)
+	// List all deployments with label app=istiod from the cache
+	selector := labels.Set{"app": "istiod"}.AsSelector()
+	allDeps, err := k.deploymentsLister.List(selector)
+	if err != nil {
+		k.logger.Debug("failed to list deployments from cache, using defaults", "error", err)
+		return config
 	}
 
-	if activeDeployment == nil {
-		k.logger.Debug("no active istiod deployment found, using default Istio configuration")
-		*result = config
-		return
+	if len(allDeps) == 0 {
+		k.logger.Debug("no istiod deployments found in cache, using default Istio configuration")
+		return config
 	}
 
-	k.logger.Debug("selected active istiod deployment", "name", activeDeployment.Name, "namespace", activeDeployment.Namespace)
+	// Group by namespace to replicate discoverIstioControlPlane logic
+	byNamespace := make(map[string][]*appsv1.Deployment)
+	for _, d := range allDeps {
+		byNamespace[d.Namespace] = append(byNamespace[d.Namespace], d)
+	}
 
-	// Extract configuration from the active deployment
-	k.extractPilotConfiguration(activeDeployment, config)
+	// Prefer istio-system namespace
+	if deps, ok := byNamespace["istio-system"]; ok {
+		active := k.selectActiveControlPlane(derefDeployments(deps))
+		if active != nil {
+			config.RootNamespace = "istio-system"
+			k.logger.Debug("selected active istiod deployment", "name", active.Name, "namespace", active.Namespace)
+			k.extractPilotConfiguration(active, config)
+			return config
+		}
+	}
 
-	*result = config
+	// Fall back to namespace with most-ready-replica deployment
+	var bestDep *appsv1.Deployment
+	var bestNS string
+	maxReady := int32(-1)
+	for ns, deps := range byNamespace {
+		active := k.selectActiveControlPlane(derefDeployments(deps))
+		if active != nil && active.Status.ReadyReplicas > maxReady {
+			maxReady = active.Status.ReadyReplicas
+			bestDep = active
+			bestNS = ns
+		}
+	}
+
+	if bestDep != nil {
+		config.RootNamespace = bestNS
+		k.logger.Debug("discovered Istio control plane", "namespace", bestNS, "deployment", bestDep.Name)
+		k.extractPilotConfiguration(bestDep, config)
+	}
+
+	return config
 }
 
-// discoverIstioControlPlane discovers the Istio control plane by searching across multiple
-// potential namespaces and returns the root namespace and active deployment.
+// discoverIstioControlPlane discovers the Istio control plane via direct API calls.
+// Used by GetClusterName before informers are started.
 func (k *Client) discoverIstioControlPlane(ctx context.Context) (string, *appsv1.Deployment) {
-	// Common namespaces where Istio control plane might be installed
 	candidateNamespaces := []string{
 		"istio-system",
 		"istio-control-plane",
@@ -652,7 +292,6 @@ func (k *Client) discoverIstioControlPlane(ctx context.Context) (string, *appsv1
 	allNamespaces, err := k.clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err == nil {
 		for _, ns := range allNamespaces.Items {
-			// Add any namespace that looks like it could contain Istio control plane
 			if ns.Name != "istio-system" &&
 				ns.Name != "istio-control-plane" &&
 				ns.Name != "istiod" &&
@@ -666,7 +305,6 @@ func (k *Client) discoverIstioControlPlane(ctx context.Context) (string, *appsv1
 	var bestNamespace string
 	maxReadyReplicas := int32(-1)
 
-	// Search each namespace for istiod deployments
 	for _, namespace := range candidateNamespaces {
 		deployments, err := k.clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=istiod",
@@ -679,19 +317,16 @@ func (k *Client) discoverIstioControlPlane(ctx context.Context) (string, *appsv1
 			continue
 		}
 
-		// Select the best deployment from this namespace
 		activeDeployment := k.selectActiveControlPlane(deployments.Items)
 		if activeDeployment == nil {
 			continue
 		}
 
-		// Prioritize traditional "istio-system" namespace
 		if namespace == "istio-system" {
 			k.logger.Debug("found istiod in traditional istio-system namespace")
 			return namespace, activeDeployment
 		}
 
-		// Otherwise, prefer deployment with most ready replicas
 		if activeDeployment.Status.ReadyReplicas > maxReadyReplicas {
 			maxReadyReplicas = activeDeployment.Status.ReadyReplicas
 			bestDeployment = activeDeployment
@@ -757,7 +392,6 @@ func (k *Client) selectActiveControlPlane(deployments []appsv1.Deployment) *apps
 
 // extractPilotConfiguration extracts pilot configuration from an istiod deployment
 func (k *Client) extractPilotConfiguration(deployment *appsv1.Deployment, config *typesv1alpha1.IstioControlPlaneConfig) {
-	// Check for PILOT_SCOPE_GATEWAY_TO_NAMESPACE environment variable in istiod deployment
 	for _, container := range deployment.Spec.Template.Spec.Containers {
 		if container.Name == "discovery" {
 			for _, env := range container.Env {
@@ -774,6 +408,344 @@ func (k *Client) extractPilotConfiguration(deployment *appsv1.Deployment, config
 	}
 }
 
+// convertDestinationRule converts an Istio DestinationRule to a protobuf DestinationRule
+func (k *Client) convertDestinationRule(dr *istionetworkingv1beta1.DestinationRule) (*typesv1alpha1.DestinationRule, error) {
+	resourceBytes, err := json.Marshal(dr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal destination rule resource: %w", err)
+	}
+
+	var host string
+	if dr.Spec.Host != "" {
+		host = dr.Spec.Host
+	}
+
+	var subsets []*typesv1alpha1.DestinationRuleSubset
+	for _, subset := range dr.Spec.Subsets {
+		protoSubset := &typesv1alpha1.DestinationRuleSubset{
+			Name:   subset.Name,
+			Labels: make(map[string]string),
+		}
+		if subset.Labels != nil {
+			for key, value := range subset.Labels {
+				protoSubset.Labels[key] = value
+			}
+		}
+		subsets = append(subsets, protoSubset)
+	}
+
+	var exportTo []string
+	if len(dr.Spec.ExportTo) > 0 {
+		exportTo = dr.Spec.ExportTo
+	} else {
+		exportTo = []string{"*"}
+	}
+
+	var workloadSelector *typesv1alpha1.WorkloadSelector
+	if dr.Spec.WorkloadSelector != nil && dr.Spec.WorkloadSelector.MatchLabels != nil {
+		matchLabels := make(map[string]string)
+		for key, value := range dr.Spec.WorkloadSelector.MatchLabels {
+			matchLabels[key] = value
+		}
+		workloadSelector = &typesv1alpha1.WorkloadSelector{
+			MatchLabels: matchLabels,
+		}
+	}
+
+	return &typesv1alpha1.DestinationRule{
+		Name:             dr.Name,
+		Namespace:        dr.Namespace,
+		RawConfig:        string(resourceBytes),
+		Host:             host,
+		Subsets:          subsets,
+		ExportTo:         exportTo,
+		WorkloadSelector: workloadSelector,
+	}, nil
+}
+
+// convertEnvoyFilter converts an Istio EnvoyFilter to a protobuf EnvoyFilter
+func (k *Client) convertEnvoyFilter(ef *istionetworkingv1alpha3.EnvoyFilter) (*typesv1alpha1.EnvoyFilter, error) {
+	resourceBytes, err := json.Marshal(ef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal envoy filter resource: %w", err)
+	}
+
+	var workloadSelector *typesv1alpha1.WorkloadSelector
+	if ef.Spec.WorkloadSelector != nil && ef.Spec.WorkloadSelector.Labels != nil {
+		matchLabels := make(map[string]string)
+		for key, value := range ef.Spec.WorkloadSelector.Labels {
+			matchLabels[key] = value
+		}
+		workloadSelector = &typesv1alpha1.WorkloadSelector{
+			MatchLabels: matchLabels,
+		}
+	}
+
+	var targetRefs []*typesv1alpha1.PolicyTargetReference
+	for _, targetRef := range ef.Spec.TargetRefs {
+		if targetRef != nil {
+			protoTargetRef := &typesv1alpha1.PolicyTargetReference{
+				Group:     targetRef.Group,
+				Kind:      targetRef.Kind,
+				Name:      targetRef.Name,
+				Namespace: targetRef.Namespace,
+			}
+			targetRefs = append(targetRefs, protoTargetRef)
+		}
+	}
+
+	return &typesv1alpha1.EnvoyFilter{
+		Name:             ef.Name,
+		Namespace:        ef.Namespace,
+		RawConfig:        string(resourceBytes),
+		WorkloadSelector: workloadSelector,
+		TargetRefs:       targetRefs,
+	}, nil
+}
+
+// convertRequestAuthentication converts an Istio RequestAuthentication to a protobuf RequestAuthentication
+func (k *Client) convertRequestAuthentication(ra *istiosecurityv1beta1.RequestAuthentication) (*typesv1alpha1.RequestAuthentication, error) {
+	resourceBytes, err := json.Marshal(ra)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request authentication resource: %w", err)
+	}
+
+	var selector *typesv1alpha1.WorkloadSelector
+	if ra.Spec.Selector != nil && ra.Spec.Selector.MatchLabels != nil {
+		matchLabels := make(map[string]string)
+		for key, value := range ra.Spec.Selector.MatchLabels {
+			matchLabels[key] = value
+		}
+		selector = &typesv1alpha1.WorkloadSelector{
+			MatchLabels: matchLabels,
+		}
+	}
+
+	var targetRefs []*typesv1alpha1.PolicyTargetReference
+	for _, targetRef := range ra.Spec.TargetRefs {
+		if targetRef != nil {
+			protoTargetRef := &typesv1alpha1.PolicyTargetReference{
+				Group:     targetRef.Group,
+				Kind:      targetRef.Kind,
+				Name:      targetRef.Name,
+				Namespace: targetRef.Namespace,
+			}
+			targetRefs = append(targetRefs, protoTargetRef)
+		}
+	}
+
+	return &typesv1alpha1.RequestAuthentication{
+		Name:       ra.Name,
+		Namespace:  ra.Namespace,
+		RawConfig:  string(resourceBytes),
+		Selector:   selector,
+		TargetRefs: targetRefs,
+	}, nil
+}
+
+// convertPeerAuthentication converts an Istio PeerAuthentication to a protobuf PeerAuthentication
+func (k *Client) convertPeerAuthentication(pa *istiosecurityv1beta1.PeerAuthentication) (*typesv1alpha1.PeerAuthentication, error) {
+	resourceBytes, err := json.Marshal(pa)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal peer authentication resource: %w", err)
+	}
+
+	var selector *typesv1alpha1.WorkloadSelector
+	if pa.Spec.Selector != nil && pa.Spec.Selector.MatchLabels != nil {
+		matchLabels := make(map[string]string)
+		for key, value := range pa.Spec.Selector.MatchLabels {
+			matchLabels[key] = value
+		}
+		selector = &typesv1alpha1.WorkloadSelector{
+			MatchLabels: matchLabels,
+		}
+	}
+
+	return &typesv1alpha1.PeerAuthentication{
+		Name:      pa.Name,
+		Namespace: pa.Namespace,
+		RawConfig: string(resourceBytes),
+		Selector:  selector,
+	}, nil
+}
+
+// convertAuthorizationPolicy converts an Istio AuthorizationPolicy to a protobuf AuthorizationPolicy
+func (k *Client) convertAuthorizationPolicy(ap *istiosecurityv1beta1.AuthorizationPolicy) (*typesv1alpha1.AuthorizationPolicy, error) {
+	resourceBytes, err := json.Marshal(ap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal authorization policy resource: %w", err)
+	}
+
+	var selector *typesv1alpha1.WorkloadSelector
+	if ap.Spec.Selector != nil && ap.Spec.Selector.MatchLabels != nil {
+		matchLabels := make(map[string]string)
+		for key, value := range ap.Spec.Selector.MatchLabels {
+			matchLabels[key] = value
+		}
+		selector = &typesv1alpha1.WorkloadSelector{
+			MatchLabels: matchLabels,
+		}
+	}
+
+	var targetRefs []*typesv1alpha1.PolicyTargetReference
+
+	// Handle TargetRef (singular) - older API
+	if ap.Spec.TargetRef != nil {
+		protoTargetRef := &typesv1alpha1.PolicyTargetReference{
+			Group:     ap.Spec.TargetRef.Group,
+			Kind:      ap.Spec.TargetRef.Kind,
+			Name:      ap.Spec.TargetRef.Name,
+			Namespace: ap.Spec.TargetRef.Namespace,
+		}
+		targetRefs = append(targetRefs, protoTargetRef)
+	}
+
+	// Handle TargetRefs (plural) - newer API
+	for _, targetRef := range ap.Spec.TargetRefs {
+		if targetRef != nil {
+			protoTargetRef := &typesv1alpha1.PolicyTargetReference{
+				Group:     targetRef.Group,
+				Kind:      targetRef.Kind,
+				Name:      targetRef.Name,
+				Namespace: targetRef.Namespace,
+			}
+			targetRefs = append(targetRefs, protoTargetRef)
+		}
+	}
+
+	return &typesv1alpha1.AuthorizationPolicy{
+		Name:       ap.Name,
+		Namespace:  ap.Namespace,
+		RawConfig:  string(resourceBytes),
+		Selector:   selector,
+		TargetRefs: targetRefs,
+	}, nil
+}
+
+// convertWasmPlugin converts an Istio WasmPlugin to a protobuf WasmPlugin
+func (k *Client) convertWasmPlugin(wp *istioextensionsv1alpha1.WasmPlugin) (*typesv1alpha1.WasmPlugin, error) {
+	resourceBytes, err := json.Marshal(wp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal wasm plugin resource: %w", err)
+	}
+
+	var selector *typesv1alpha1.WorkloadSelector
+	if wp.Spec.Selector != nil && wp.Spec.Selector.MatchLabels != nil {
+		matchLabels := make(map[string]string)
+		for key, value := range wp.Spec.Selector.MatchLabels {
+			matchLabels[key] = value
+		}
+		selector = &typesv1alpha1.WorkloadSelector{
+			MatchLabels: matchLabels,
+		}
+	}
+
+	var targetRefs []*typesv1alpha1.PolicyTargetReference
+	for _, targetRef := range wp.Spec.TargetRefs {
+		if targetRef != nil {
+			protoTargetRef := &typesv1alpha1.PolicyTargetReference{
+				Group:     targetRef.Group,
+				Kind:      targetRef.Kind,
+				Name:      targetRef.Name,
+				Namespace: targetRef.Namespace,
+			}
+			targetRefs = append(targetRefs, protoTargetRef)
+		}
+	}
+
+	return &typesv1alpha1.WasmPlugin{
+		Name:       wp.Name,
+		Namespace:  wp.Namespace,
+		RawConfig:  string(resourceBytes),
+		Selector:   selector,
+		TargetRefs: targetRefs,
+	}, nil
+}
+
+// convertGateway converts an Istio Gateway to a protobuf Gateway
+func (k *Client) convertGateway(gw *istionetworkingv1beta1.Gateway) (*typesv1alpha1.Gateway, error) {
+	resourceBytes, err := json.Marshal(gw)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal gateway resource: %w", err)
+	}
+
+	selector := make(map[string]string)
+	if gw.Spec.Selector != nil {
+		for key, value := range gw.Spec.Selector {
+			selector[key] = value
+		}
+	}
+
+	return &typesv1alpha1.Gateway{
+		Name:      gw.Name,
+		Namespace: gw.Namespace,
+		RawConfig: string(resourceBytes),
+		Selector:  selector,
+	}, nil
+}
+
+// convertSidecar converts an Istio Sidecar to a protobuf Sidecar
+func (k *Client) convertSidecar(sc *istionetworkingv1beta1.Sidecar) (*typesv1alpha1.Sidecar, error) {
+	resourceBytes, err := json.Marshal(sc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal sidecar resource: %w", err)
+	}
+
+	var workloadSelector *typesv1alpha1.WorkloadSelector
+	if sc.Spec.WorkloadSelector != nil && sc.Spec.WorkloadSelector.Labels != nil {
+		matchLabels := make(map[string]string)
+		for key, value := range sc.Spec.WorkloadSelector.Labels {
+			matchLabels[key] = value
+		}
+		workloadSelector = &typesv1alpha1.WorkloadSelector{
+			MatchLabels: matchLabels,
+		}
+	}
+
+	return &typesv1alpha1.Sidecar{
+		Name:             sc.Name,
+		Namespace:        sc.Namespace,
+		RawConfig:        string(resourceBytes),
+		WorkloadSelector: workloadSelector,
+	}, nil
+}
+
+// convertVirtualService converts an Istio VirtualService to a protobuf VirtualService
+func (k *Client) convertVirtualService(vs *istionetworkingv1beta1.VirtualService) (*typesv1alpha1.VirtualService, error) {
+	resourceBytes, err := json.Marshal(vs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal virtual service resource: %w", err)
+	}
+
+	var hosts []string
+	if vs.Spec.Hosts != nil {
+		hosts = vs.Spec.Hosts
+	}
+
+	var gateways []string
+	if len(vs.Spec.Gateways) > 0 {
+		gateways = vs.Spec.Gateways
+	} else {
+		gateways = []string{"mesh"}
+	}
+
+	var exportTo []string
+	if len(vs.Spec.ExportTo) > 0 {
+		exportTo = vs.Spec.ExportTo
+	} else {
+		exportTo = []string{"*"}
+	}
+
+	return &typesv1alpha1.VirtualService{
+		Name:      vs.Name,
+		Namespace: vs.Namespace,
+		RawConfig: string(resourceBytes),
+		Hosts:     hosts,
+		Gateways:  gateways,
+		ExportTo:  exportTo,
+	}, nil
+}
+
 // convertServiceEntry converts an Istio ServiceEntry to a protobuf ServiceEntry
 func (k *Client) convertServiceEntry(se *istionetworkingv1beta1.ServiceEntry) (*typesv1alpha1.ServiceEntry, error) {
 	resourceBytes, err := json.Marshal(se)
@@ -781,7 +753,6 @@ func (k *Client) convertServiceEntry(se *istionetworkingv1beta1.ServiceEntry) (*
 		return nil, fmt.Errorf("failed to marshal service entry resource: %w", err)
 	}
 
-	// Default for exportTo is ["*"] if not specified or empty
 	var exportTo []string
 	if len(se.Spec.ExportTo) > 0 {
 		exportTo = se.Spec.ExportTo
@@ -795,4 +766,13 @@ func (k *Client) convertServiceEntry(se *istionetworkingv1beta1.ServiceEntry) (*
 		RawConfig: string(resourceBytes),
 		ExportTo:  exportTo,
 	}, nil
+}
+
+// derefDeployments converts a slice of Deployment pointers to values
+func derefDeployments(ptrs []*appsv1.Deployment) []appsv1.Deployment {
+	out := make([]appsv1.Deployment, len(ptrs))
+	for i, p := range ptrs {
+		out[i] = *p
+	}
+	return out
 }

--- a/edge/pkg/kubernetes/istio_test.go
+++ b/edge/pkg/kubernetes/istio_test.go
@@ -429,6 +429,61 @@ func TestClient_getIstioControlPlaneConfig(t *testing.T) {
 	}
 }
 
+func TestClient_selectActiveControlPlane(t *testing.T) {
+	client := &Client{logger: logging.For("test")}
+
+	dep := func(name string, ready int32) appsv1.Deployment {
+		return appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "istio-system"},
+			Status:     appsv1.DeploymentStatus{ReadyReplicas: ready},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		deployments []appsv1.Deployment
+		wantName    string
+	}{
+		{
+			name:        "empty list returns nil",
+			deployments: nil,
+			wantName:    "",
+		},
+		{
+			name:        "single deployment selected",
+			deployments: []appsv1.Deployment{dep("istiod-1-26-0", 2)},
+			wantName:    "istiod-1-26-0",
+		},
+		{
+			name:        "traditional istiod preferred regardless of replica count",
+			deployments: []appsv1.Deployment{dep("istiod-1-26-0", 5), dep("istiod", 1)},
+			wantName:    "istiod",
+		},
+		{
+			name:        "highest ready replicas wins",
+			deployments: []appsv1.Deployment{dep("istiod-1-25-0", 1), dep("istiod-1-26-0", 3)},
+			wantName:    "istiod-1-26-0",
+		},
+		{
+			name:        "same ready replicas - first in slice selected",
+			deployments: []appsv1.Deployment{dep("istiod-1-25-0", 2), dep("istiod-1-26-0", 2)},
+			wantName:    "istiod-1-25-0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := client.selectActiveControlPlane(tt.deployments)
+			if tt.wantName == "" {
+				assert.Nil(t, result)
+			} else {
+				require.NotNil(t, result)
+				assert.Equal(t, tt.wantName, result.Name)
+			}
+		})
+	}
+}
+
 func TestClient_convertVirtualService(t *testing.T) {
 	client := &Client{logger: logging.For("test")}
 
@@ -725,7 +780,7 @@ func TestClient_convertSidecar(t *testing.T) {
 			assert.NotEmpty(t, result.RawConfig)
 
 			// Verify RawConfig contains valid JSON
-			var spec map[string]interface{}
+			var spec map[string]any
 			err = json.Unmarshal([]byte(result.RawConfig), &spec)
 			assert.NoError(t, err, "RawConfig should be valid JSON")
 		})
@@ -969,7 +1024,7 @@ func TestClient_convertPeerAuthentication(t *testing.T) {
 			assert.NotEmpty(t, result.RawConfig)
 
 			// Verify RawConfig contains valid JSON
-			var spec map[string]interface{}
+			var spec map[string]any
 			err = json.Unmarshal([]byte(result.RawConfig), &spec)
 			assert.NoError(t, err, "RawConfig should be valid JSON")
 		})
@@ -1227,7 +1282,7 @@ func TestClient_convertWasmPlugin(t *testing.T) {
 			assert.Equal(t, tt.wantNamespace, result.Namespace)
 
 			// Verify that RawConfig is valid JSON
-			var spec map[string]interface{}
+			var spec map[string]any
 			err = json.Unmarshal([]byte(result.RawConfig), &spec)
 			assert.NoError(t, err, "RawConfig should be valid JSON")
 
@@ -1425,7 +1480,7 @@ func TestClient_convertServiceEntry(t *testing.T) {
 			assert.NotEmpty(t, result.RawConfig)
 
 			// Verify RawConfig contains valid JSON
-			var spec map[string]interface{}
+			var spec map[string]any
 			err = json.Unmarshal([]byte(result.RawConfig), &spec)
 			assert.NoError(t, err, "RawConfig should be valid JSON")
 		})
@@ -1698,7 +1753,7 @@ func TestClient_convertAuthorizationPolicy(t *testing.T) {
 			assert.Equal(t, tt.wantTargetRefs, result.TargetRefs)
 
 			// Verify RawConfig is valid JSON
-			var jsonData interface{}
+			var jsonData any
 			err = json.Unmarshal([]byte(result.RawConfig), &jsonData)
 			assert.NoError(t, err, "RawConfig should be valid JSON")
 		})

--- a/edge/pkg/kubernetes/istio_test.go
+++ b/edge/pkg/kubernetes/istio_test.go
@@ -15,9 +15,7 @@
 package kubernetes
 
 import (
-	"context"
 	"encoding/json"
-	"sync"
 	"testing"
 
 	typesv1alpha1 "github.com/liamawhite/navigator/pkg/api/types/v1alpha1"
@@ -34,7 +32,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestClient_convertDestinationRule(t *testing.T) {
@@ -315,9 +313,7 @@ func TestClient_convertGateway(t *testing.T) {
 	}
 }
 
-func TestClient_fetchIstioControlPlaneConfig(t *testing.T) {
-	client := &Client{logger: logging.For("test")}
-
+func TestClient_getIstioControlPlaneConfig(t *testing.T) {
 	type testDeployment struct {
 		name          string
 		envVars       []corev1.EnvVar
@@ -328,13 +324,11 @@ func TestClient_fetchIstioControlPlaneConfig(t *testing.T) {
 		name                             string
 		deployments                      []testDeployment
 		wantPilotScopeGatewayToNamespace bool
-		expectedSelectedDeployment       string
 	}{
 		{
 			name:                             "no deployments found - default config",
 			deployments:                      []testDeployment{},
 			wantPilotScopeGatewayToNamespace: false,
-			expectedSelectedDeployment:       "",
 		},
 		{
 			name: "single traditional istiod - no env var set",
@@ -342,7 +336,6 @@ func TestClient_fetchIstioControlPlaneConfig(t *testing.T) {
 				{name: "istiod", envVars: []corev1.EnvVar{}, readyReplicas: 1},
 			},
 			wantPilotScopeGatewayToNamespace: false,
-			expectedSelectedDeployment:       "istiod",
 		},
 		{
 			name: "single traditional istiod - env var set to true",
@@ -356,7 +349,6 @@ func TestClient_fetchIstioControlPlaneConfig(t *testing.T) {
 				},
 			},
 			wantPilotScopeGatewayToNamespace: true,
-			expectedSelectedDeployment:       "istiod",
 		},
 		{
 			name: "canary upgrade - traditional istiod preferred",
@@ -365,7 +357,6 @@ func TestClient_fetchIstioControlPlaneConfig(t *testing.T) {
 				{name: "istiod-1-26-0", envVars: []corev1.EnvVar{{Name: "PILOT_SCOPE_GATEWAY_TO_NAMESPACE", Value: "true"}}, readyReplicas: 2},
 			},
 			wantPilotScopeGatewayToNamespace: false, // Should use traditional istiod
-			expectedSelectedDeployment:       "istiod",
 		},
 		{
 			name: "canary upgrade - no traditional istiod, select by ready replicas",
@@ -375,7 +366,6 @@ func TestClient_fetchIstioControlPlaneConfig(t *testing.T) {
 				{name: "istiod-canary", envVars: []corev1.EnvVar{}, readyReplicas: 2},
 			},
 			wantPilotScopeGatewayToNamespace: true, // Should use istiod-1-26-0 (highest replicas)
-			expectedSelectedDeployment:       "istiod-1-26-0",
 		},
 		{
 			name: "revision-based install - single deployment",
@@ -389,16 +379,6 @@ func TestClient_fetchIstioControlPlaneConfig(t *testing.T) {
 				},
 			},
 			wantPilotScopeGatewayToNamespace: true,
-			expectedSelectedDeployment:       "istiod-1-26-0",
-		},
-		{
-			name: "multiple deployments - same ready replicas, use first",
-			deployments: []testDeployment{
-				{name: "istiod-1-25-0", envVars: []corev1.EnvVar{}, readyReplicas: 2},
-				{name: "istiod-1-26-0", envVars: []corev1.EnvVar{{Name: "PILOT_SCOPE_GATEWAY_TO_NAMESPACE", Value: "true"}}, readyReplicas: 2},
-			},
-			wantPilotScopeGatewayToNamespace: false, // Should use first one (istiod-1-25-0)
-			expectedSelectedDeployment:       "istiod-1-25-0",
 		},
 		{
 			name: "deployment with zero ready replicas",
@@ -406,17 +386,12 @@ func TestClient_fetchIstioControlPlaneConfig(t *testing.T) {
 				{name: "istiod-1-26-0", envVars: []corev1.EnvVar{{Name: "PILOT_SCOPE_GATEWAY_TO_NAMESPACE", Value: "true"}}, readyReplicas: 0},
 			},
 			wantPilotScopeGatewayToNamespace: true,
-			expectedSelectedDeployment:       "istiod-1-26-0",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create fake Kubernetes client
-			k8sClient := fake.NewSimpleClientset()
-			client.clientset = k8sClient
-
-			// Create all specified deployments
+			var k8sObjects []runtime.Object
 			for _, deployment := range tt.deployments {
 				dep := &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
@@ -442,30 +417,12 @@ func TestClient_fetchIstioControlPlaneConfig(t *testing.T) {
 						ReadyReplicas: deployment.readyReplicas,
 					},
 				}
-				_, err := k8sClient.AppsV1().Deployments("istio-system").Create(context.TODO(), dep, metav1.CreateOptions{})
-				require.NoError(t, err)
+				k8sObjects = append(k8sObjects, dep)
 			}
 
-			var wg sync.WaitGroup
-			var result *typesv1alpha1.IstioControlPlaneConfig
-			errChan := make(chan error, 1)
-			wg.Add(1)
+			client := newTestClient(t, k8sObjects, nil)
+			result := client.getIstioControlPlaneConfig()
 
-			client.fetchIstioControlPlaneConfig(context.TODO(), &wg, &result, errChan)
-
-			wg.Wait()
-			close(errChan)
-
-			// Check for errors
-			var errors []error
-			for err := range errChan {
-				if err != nil {
-					errors = append(errors, err)
-				}
-			}
-			assert.Empty(t, errors, "No errors should occur during config detection")
-
-			// Verify result
 			require.NotNil(t, result)
 			assert.Equal(t, tt.wantPilotScopeGatewayToNamespace, result.PilotScopeGatewayToNamespace)
 		})

--- a/edge/pkg/kubernetes/istio_test.go
+++ b/edge/pkg/kubernetes/istio_test.go
@@ -432,8 +432,8 @@ func TestClient_getIstioControlPlaneConfig(t *testing.T) {
 func TestClient_selectActiveControlPlane(t *testing.T) {
 	client := &Client{logger: logging.For("test")}
 
-	dep := func(name string, ready int32) appsv1.Deployment {
-		return appsv1.Deployment{
+	dep := func(name string, ready int32) *appsv1.Deployment {
+		return &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "istio-system"},
 			Status:     appsv1.DeploymentStatus{ReadyReplicas: ready},
 		}
@@ -441,7 +441,7 @@ func TestClient_selectActiveControlPlane(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		deployments []appsv1.Deployment
+		deployments []*appsv1.Deployment
 		wantName    string
 	}{
 		{
@@ -451,22 +451,22 @@ func TestClient_selectActiveControlPlane(t *testing.T) {
 		},
 		{
 			name:        "single deployment selected",
-			deployments: []appsv1.Deployment{dep("istiod-1-26-0", 2)},
+			deployments: []*appsv1.Deployment{dep("istiod-1-26-0", 2)},
 			wantName:    "istiod-1-26-0",
 		},
 		{
 			name:        "traditional istiod preferred regardless of replica count",
-			deployments: []appsv1.Deployment{dep("istiod-1-26-0", 5), dep("istiod", 1)},
+			deployments: []*appsv1.Deployment{dep("istiod-1-26-0", 5), dep("istiod", 1)},
 			wantName:    "istiod",
 		},
 		{
 			name:        "highest ready replicas wins",
-			deployments: []appsv1.Deployment{dep("istiod-1-25-0", 1), dep("istiod-1-26-0", 3)},
+			deployments: []*appsv1.Deployment{dep("istiod-1-25-0", 1), dep("istiod-1-26-0", 3)},
 			wantName:    "istiod-1-26-0",
 		},
 		{
 			name:        "same ready replicas - first in slice selected",
-			deployments: []appsv1.Deployment{dep("istiod-1-25-0", 2), dep("istiod-1-26-0", 2)},
+			deployments: []*appsv1.Deployment{dep("istiod-1-25-0", 2), dep("istiod-1-26-0", 2)},
 			wantName:    "istiod-1-25-0",
 		},
 	}

--- a/edge/pkg/kubernetes/kubernetes.go
+++ b/edge/pkg/kubernetes/kubernetes.go
@@ -16,6 +16,9 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	backendv1alpha1 "github.com/liamawhite/navigator/pkg/api/backend/v1alpha1"
@@ -27,29 +30,25 @@ import (
 )
 
 // buildEndpointSliceMap creates a map of service name to endpoint slices for efficient lookup
-func (k *Client) buildEndpointSliceMap(endpointSlices []discoveryv1.EndpointSlice) map[string][]discoveryv1.EndpointSlice {
+func (k *Client) buildEndpointSliceMap(endpointSlices []*discoveryv1.EndpointSlice) map[string][]discoveryv1.EndpointSlice {
 	endpointSlicesByService := make(map[string][]discoveryv1.EndpointSlice)
-
 	for _, slice := range endpointSlices {
 		serviceName := slice.Labels["kubernetes.io/service-name"]
 		if serviceName != "" {
 			key := slice.Namespace + "/" + serviceName
-			endpointSlicesByService[key] = append(endpointSlicesByService[key], slice)
+			endpointSlicesByService[key] = append(endpointSlicesByService[key], *slice)
 		}
 	}
-
 	return endpointSlicesByService
 }
 
 // buildPodMap creates a map of namespace/podname to pod for efficient lookup
-func (k *Client) buildPodMap(pods []corev1.Pod) map[string]*corev1.Pod {
+func (k *Client) buildPodMap(pods []*corev1.Pod) map[string]*corev1.Pod {
 	podsByName := make(map[string]*corev1.Pod)
-
-	for i, pod := range pods {
+	for _, pod := range pods {
 		key := pod.Namespace + "/" + pod.Name
-		podsByName[key] = &pods[i]
+		podsByName[key] = pod
 	}
-
 	return podsByName
 }
 
@@ -132,14 +131,10 @@ func (k *Client) convertEndpointSlicesToInstancesWithMaps(
 
 					// Copy labels and annotations (avoid nil maps)
 					if pod.Labels != nil {
-						for k, v := range pod.Labels {
-							lbls[k] = v
-						}
+						maps.Copy(lbls, pod.Labels)
 					}
 					if pod.Annotations != nil {
-						for k, v := range pod.Annotations {
-							annotations[k] = v
-						}
+						maps.Copy(annotations, pod.Annotations)
 					}
 				}
 			}
@@ -168,21 +163,8 @@ func (k *Client) convertEndpointSlicesToInstancesWithMaps(
 
 // hasEnvoySidecarInPod checks if a pod has an Envoy sidecar container (no API call)
 func (k *Client) hasEnvoySidecarInPod(pod *corev1.Pod) bool {
-	// Check all containers for Envoy indicators
-	for _, container := range pod.Spec.Containers {
-		if k.isEnvoyContainer(container) {
-			return true
-		}
-	}
-
-	// Check init containers as well
-	for _, container := range pod.Spec.InitContainers {
-		if k.isEnvoyContainer(container) {
-			return true
-		}
-	}
-
-	return false
+	return slices.ContainsFunc(pod.Spec.Containers, k.isEnvoyContainer) ||
+		slices.ContainsFunc(pod.Spec.InitContainers, k.isEnvoyContainer)
 }
 
 // isEnvoyContainer checks if a container is an Envoy proxy
@@ -252,7 +234,12 @@ func (k *Client) extractContainerInfo(pod *corev1.Pod) []*backendv1alpha1.Contai
 
 // GetClusterState reads cluster state from the informer cache.
 // Start must be called before this method.
+// TODO: propagate ctx cancellation through lister reads once the interface supports it.
 func (k *Client) GetClusterState(_ context.Context) (*backendv1alpha1.ClusterState, error) {
+	if k.servicesLister == nil {
+		return nil, fmt.Errorf("informer cache not initialised: call Start first")
+	}
+
 	// Read k8s resources from the local cache
 	svcPtrs, err := k.servicesLister.List(labels.Everything())
 	if err != nil {
@@ -267,13 +254,18 @@ func (k *Client) GetClusterState(_ context.Context) (*backendv1alpha1.ClusterSta
 		return nil, err
 	}
 
-	podsByName := k.buildPodMap(derefPods(podPtrs))
-	endpointSlicesByService := k.buildEndpointSliceMap(derefEndpointSlices(epsPtrs))
+	podsByName := k.buildPodMap(podPtrs)
+	endpointSlicesByService := k.buildEndpointSliceMap(epsPtrs)
 
 	var protoServices []*backendv1alpha1.Service
 	for _, svc := range svcPtrs {
 		protoServices = append(protoServices, k.convertServiceWithMaps(svc, endpointSlicesByService, podsByName))
 	}
+
+	// k8s lister errors are hard failures: no services/pods means broken state.
+	// Istio lister errors in listXxx are logged and return nil (best-effort):
+	// Lister.List() on a synced in-memory cache never errors in practice, and
+	// missing Istio config is non-fatal — workload state is still reported.
 
 	// Read Istio resources from the local cache
 	protoDestinationRules := k.listDestinationRules()
@@ -382,20 +374,3 @@ func (k *Client) determineProxyMode(pod *corev1.Pod) typesv1alpha1.ProxyMode {
 	return typesv1alpha1.ProxyMode_NONE
 }
 
-// derefPods converts a slice of pod pointers to pod values
-func derefPods(ptrs []*corev1.Pod) []corev1.Pod {
-	out := make([]corev1.Pod, len(ptrs))
-	for i, p := range ptrs {
-		out[i] = *p
-	}
-	return out
-}
-
-// derefEndpointSlices converts a slice of EndpointSlice pointers to values
-func derefEndpointSlices(ptrs []*discoveryv1.EndpointSlice) []discoveryv1.EndpointSlice {
-	out := make([]discoveryv1.EndpointSlice, len(ptrs))
-	for i, p := range ptrs {
-		out[i] = *p
-	}
-	return out
-}

--- a/edge/pkg/kubernetes/kubernetes.go
+++ b/edge/pkg/kubernetes/kubernetes.go
@@ -16,16 +16,14 @@ package kubernetes
 
 import (
 	"context"
-	"fmt"
 	"strings"
-	"sync"
 
 	backendv1alpha1 "github.com/liamawhite/navigator/pkg/api/backend/v1alpha1"
 	typesv1alpha1 "github.com/liamawhite/navigator/pkg/api/types/v1alpha1"
 	"istio.io/api/label"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // buildEndpointSliceMap creates a map of service name to endpoint slices for efficient lookup
@@ -112,7 +110,7 @@ func (k *Client) convertEndpointSlicesToInstancesWithMaps(
 			podStatus := ""
 			nodeName := ""
 			createdAt := ""
-			labels := make(map[string]string)
+			lbls := make(map[string]string)
 			annotations := make(map[string]string)
 			proxyMode := typesv1alpha1.ProxyMode_NONE
 
@@ -135,7 +133,7 @@ func (k *Client) convertEndpointSlicesToInstancesWithMaps(
 					// Copy labels and annotations (avoid nil maps)
 					if pod.Labels != nil {
 						for k, v := range pod.Labels {
-							labels[k] = v
+							lbls[k] = v
 						}
 					}
 					if pod.Annotations != nil {
@@ -156,7 +154,7 @@ func (k *Client) convertEndpointSlicesToInstancesWithMaps(
 					PodStatus:    podStatus,
 					NodeName:     nodeName,
 					CreatedAt:    createdAt,
-					Labels:       labels,
+					Labels:       lbls,
 					Annotations:  annotations,
 					ProxyMode:    proxyMode,
 				}
@@ -252,36 +250,58 @@ func (k *Client) extractContainerInfo(pod *corev1.Pod) []*backendv1alpha1.Contai
 	return containers
 }
 
-// fetchServices fetches all services from the cluster
-func (k *Client) fetchServices(ctx context.Context, wg *sync.WaitGroup, result **corev1.ServiceList, errChan chan<- error) {
-	defer wg.Done()
-	servicesList, err := k.clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
-	*result = servicesList
+// GetClusterState reads cluster state from the informer cache.
+// Start must be called before this method.
+func (k *Client) GetClusterState(_ context.Context) (*backendv1alpha1.ClusterState, error) {
+	// Read k8s resources from the local cache
+	svcPtrs, err := k.servicesLister.List(labels.Everything())
 	if err != nil {
-		errChan <- fmt.Errorf("failed to list services: %w", err)
+		return nil, err
 	}
-}
+	podPtrs, err := k.podsLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	epsPtrs, err := k.endpointSlicesLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
 
-// fetchEndpointSlices fetches all endpoint slices and builds a service map
-func (k *Client) fetchEndpointSlices(ctx context.Context, wg *sync.WaitGroup, endpointSlicesByService *map[string][]discoveryv1.EndpointSlice, errChan chan<- error) {
-	defer wg.Done()
-	endpointSlicesResult, err := k.clientset.DiscoveryV1().EndpointSlices("").List(ctx, metav1.ListOptions{})
-	if err != nil {
-		errChan <- fmt.Errorf("failed to list endpoint slices: %w", err)
-		return
-	}
-	*endpointSlicesByService = k.buildEndpointSliceMap(endpointSlicesResult.Items)
-}
+	podsByName := k.buildPodMap(derefPods(podPtrs))
+	endpointSlicesByService := k.buildEndpointSliceMap(derefEndpointSlices(epsPtrs))
 
-// fetchPods fetches all pods and builds a name map
-func (k *Client) fetchPods(ctx context.Context, wg *sync.WaitGroup, podsByName *map[string]*corev1.Pod, errChan chan<- error) {
-	defer wg.Done()
-	podsResult, err := k.clientset.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
-	if err != nil {
-		errChan <- fmt.Errorf("failed to list pods: %w", err)
-		return
+	var protoServices []*backendv1alpha1.Service
+	for _, svc := range svcPtrs {
+		protoServices = append(protoServices, k.convertServiceWithMaps(svc, endpointSlicesByService, podsByName))
 	}
-	*podsByName = k.buildPodMap(podsResult.Items)
+
+	// Read Istio resources from the local cache
+	protoDestinationRules := k.listDestinationRules()
+	protoEnvoyFilters := k.listEnvoyFilters()
+	protoRequestAuthentications := k.listRequestAuthentications()
+	protoPeerAuthentications := k.listPeerAuthentications()
+	protoAuthorizationPolicies := k.listAuthorizationPolicies()
+	protoWasmPlugins := k.listWasmPlugins()
+	protoGateways := k.listGateways()
+	protoSidecars := k.listSidecars()
+	protoVirtualServices := k.listVirtualServices()
+	protoServiceEntries := k.listServiceEntries()
+	protoIstioControlPlaneConfig := k.getIstioControlPlaneConfig()
+
+	return &backendv1alpha1.ClusterState{
+		Services:                protoServices,
+		DestinationRules:        protoDestinationRules,
+		EnvoyFilters:            protoEnvoyFilters,
+		RequestAuthentications:  protoRequestAuthentications,
+		Gateways:                protoGateways,
+		Sidecars:                protoSidecars,
+		VirtualServices:         protoVirtualServices,
+		IstioControlPlaneConfig: protoIstioControlPlaneConfig,
+		PeerAuthentications:     protoPeerAuthentications,
+		AuthorizationPolicies:   protoAuthorizationPolicies,
+		WasmPlugins:             protoWasmPlugins,
+		ServiceEntries:          protoServiceEntries,
+	}, nil
 }
 
 // convertServiceType converts Kubernetes service type to protobuf ServiceType enum
@@ -325,20 +345,20 @@ func (k *Client) determineProxyMode(pod *corev1.Pod) typesv1alpha1.ProxyMode {
 		return typesv1alpha1.ProxyMode_UNKNOWN_PROXY_MODE
 	}
 
-	labels := pod.Labels
+	lbls := pod.Labels
 
 	// Check for waypoint first (to exclude them from being identified as gateways)
 	// The istio.io/waypoint-for label is the definitive waypoint indicator
-	if labels[label.IoIstioWaypointFor.Name] != "" {
+	if lbls[label.IoIstioWaypointFor.Name] != "" {
 		return typesv1alpha1.ProxyMode_SIDECAR // Waypoints are L7 proxies, not gateways
 	}
 
 	// Check for gateway labels using constants where available - these indicate router mode
-	if labels["istio.io/gateway-name"] != "" ||
-		labels[label.IoK8sNetworkingGatewayGatewayName.Name] != "" ||
-		labels["app"] == "istio-ingressgateway" ||
-		labels["app"] == "istio-egressgateway" ||
-		labels["istio"] == "ingressgateway" {
+	if lbls["istio.io/gateway-name"] != "" ||
+		lbls[label.IoK8sNetworkingGatewayGatewayName.Name] != "" ||
+		lbls["app"] == "istio-ingressgateway" ||
+		lbls["app"] == "istio-egressgateway" ||
+		lbls["istio"] == "ingressgateway" {
 		return typesv1alpha1.ProxyMode_ROUTER
 	}
 
@@ -360,4 +380,22 @@ func (k *Client) determineProxyMode(pod *corev1.Pod) typesv1alpha1.ProxyMode {
 	}
 
 	return typesv1alpha1.ProxyMode_NONE
+}
+
+// derefPods converts a slice of pod pointers to pod values
+func derefPods(ptrs []*corev1.Pod) []corev1.Pod {
+	out := make([]corev1.Pod, len(ptrs))
+	for i, p := range ptrs {
+		out[i] = *p
+	}
+	return out
+}
+
+// derefEndpointSlices converts a slice of EndpointSlice pointers to values
+func derefEndpointSlices(ptrs []*discoveryv1.EndpointSlice) []discoveryv1.EndpointSlice {
+	out := make([]discoveryv1.EndpointSlice, len(ptrs))
+	for i, p := range ptrs {
+		out[i] = *p
+	}
+	return out
 }

--- a/edge/pkg/kubernetes/kubernetes.go
+++ b/edge/pkg/kubernetes/kubernetes.go
@@ -30,13 +30,13 @@ import (
 )
 
 // buildEndpointSliceMap creates a map of service name to endpoint slices for efficient lookup
-func (k *Client) buildEndpointSliceMap(endpointSlices []*discoveryv1.EndpointSlice) map[string][]discoveryv1.EndpointSlice {
-	endpointSlicesByService := make(map[string][]discoveryv1.EndpointSlice)
+func (k *Client) buildEndpointSliceMap(endpointSlices []*discoveryv1.EndpointSlice) map[string][]*discoveryv1.EndpointSlice {
+	endpointSlicesByService := make(map[string][]*discoveryv1.EndpointSlice)
 	for _, slice := range endpointSlices {
 		serviceName := slice.Labels["kubernetes.io/service-name"]
 		if serviceName != "" {
 			key := slice.Namespace + "/" + serviceName
-			endpointSlicesByService[key] = append(endpointSlicesByService[key], *slice)
+			endpointSlicesByService[key] = append(endpointSlicesByService[key], slice)
 		}
 	}
 	return endpointSlicesByService
@@ -55,7 +55,7 @@ func (k *Client) buildPodMap(pods []*corev1.Pod) map[string]*corev1.Pod {
 // convertServiceWithMaps converts a Kubernetes Service to a protobuf Service using prebuilt maps
 func (k *Client) convertServiceWithMaps(
 	svc *corev1.Service,
-	endpointSlicesByService map[string][]discoveryv1.EndpointSlice,
+	endpointSlicesByService map[string][]*discoveryv1.EndpointSlice,
 	podsByName map[string]*corev1.Pod,
 ) *backendv1alpha1.Service {
 	protoService := &backendv1alpha1.Service{
@@ -85,7 +85,7 @@ func (k *Client) convertServiceWithMaps(
 
 // convertEndpointSlicesToInstancesWithMaps converts EndpointSlices to ServiceInstances using prebuilt maps
 func (k *Client) convertEndpointSlicesToInstancesWithMaps(
-	endpointSlices []discoveryv1.EndpointSlice,
+	endpointSlices []*discoveryv1.EndpointSlice,
 	podsByName map[string]*corev1.Pod,
 ) []*backendv1alpha1.ServiceInstance {
 	var instances []*backendv1alpha1.ServiceInstance
@@ -236,7 +236,7 @@ func (k *Client) extractContainerInfo(pod *corev1.Pod) []*backendv1alpha1.Contai
 // Start must be called before this method.
 // TODO: propagate ctx cancellation through lister reads once the interface supports it.
 func (k *Client) GetClusterState(_ context.Context) (*backendv1alpha1.ClusterState, error) {
-	if k.servicesLister == nil {
+	if !k.started {
 		return nil, fmt.Errorf("informer cache not initialised: call Start first")
 	}
 

--- a/edge/pkg/kubernetes/kubernetes.go
+++ b/edge/pkg/kubernetes/kubernetes.go
@@ -373,4 +373,3 @@ func (k *Client) determineProxyMode(pod *corev1.Pod) typesv1alpha1.ProxyMode {
 
 	return typesv1alpha1.ProxyMode_NONE
 }
-

--- a/edge/pkg/kubernetes/kubernetes_bench_test.go
+++ b/edge/pkg/kubernetes/kubernetes_bench_test.go
@@ -58,11 +58,11 @@ func benchmarkGetClusterState(b *testing.B, numServices, numPods int) {
 	for i := range services {
 		k8sObjects = append(k8sObjects, &services[i])
 	}
-	for i := range endpointSlices {
-		k8sObjects = append(k8sObjects, &endpointSlices[i])
+	for _, eps := range endpointSlices {
+		k8sObjects = append(k8sObjects, eps)
 	}
-	for i := range pods {
-		k8sObjects = append(k8sObjects, &pods[i])
+	for _, pod := range pods {
+		k8sObjects = append(k8sObjects, pod)
 	}
 
 	k8sClient := newTestClient(b, k8sObjects, nil)
@@ -72,7 +72,7 @@ func benchmarkGetClusterState(b *testing.B, numServices, numPods int) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := k8sClient.GetClusterState(context.TODO())
 		if err != nil {
 			b.Fatalf("GetClusterState failed: %v", err)
@@ -95,14 +95,14 @@ func BenchmarkMapOperations(b *testing.B) {
 
 	b.Run("BuildEndpointSliceMap", func(b *testing.B) {
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = client.buildEndpointSliceMap(endpointSlices)
 		}
 	})
 
 	b.Run("BuildPodMap", func(b *testing.B) {
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			_ = client.buildPodMap(pods)
 		}
 	})
@@ -113,8 +113,8 @@ func BenchmarkMapOperations(b *testing.B) {
 
 	b.Run("MapLookups", func(b *testing.B) {
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			for j := 0; j < 100; j++ {
+		for range b.N {
+			for j := range 100 {
 				serviceKey := fmt.Sprintf("default/service-%d", j%numServices)
 				podKey := fmt.Sprintf("default/pod-%d", j%numPods)
 
@@ -129,7 +129,7 @@ func BenchmarkMapOperations(b *testing.B) {
 func generateServices(count int) []corev1.Service {
 	services := make([]corev1.Service, count)
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		services[i] = corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("service-%d", i),
@@ -153,76 +153,53 @@ func generateServices(count int) []corev1.Service {
 }
 
 // generateEndpointSlices creates test endpoint slices
-func generateEndpointSlices(numServices, numPods int) []discoveryv1.EndpointSlice {
-	endpointSlices := make([]discoveryv1.EndpointSlice, numServices)
-
-	for i := 0; i < numServices; i++ {
-		// Create 1-3 endpoints per service
+func generateEndpointSlices(numServices, numPods int) []*discoveryv1.EndpointSlice {
+	endpointSlices := make([]*discoveryv1.EndpointSlice, numServices)
+	for i := range numServices {
 		numEndpoints := 1 + (i % 3)
 		endpoints := make([]discoveryv1.Endpoint, numEndpoints)
-
-		for j := 0; j < numEndpoints; j++ {
+		for j := range numEndpoints {
 			podIndex := (i*3 + j) % numPods
 			endpoints[j] = discoveryv1.Endpoint{
-				Addresses: []string{fmt.Sprintf("10.0.%d.%d", i%256, j%256)},
-				Conditions: discoveryv1.EndpointConditions{
-					Ready: boolPtr(true),
-				},
+				Addresses:  []string{fmt.Sprintf("10.0.%d.%d", i%256, j%256)},
+				Conditions: discoveryv1.EndpointConditions{Ready: boolPtr(true)},
 				TargetRef: &corev1.ObjectReference{
 					Kind: "Pod",
 					Name: fmt.Sprintf("pod-%d", podIndex),
 				},
 			}
 		}
-
-		endpointSlices[i] = discoveryv1.EndpointSlice{
+		endpointSlices[i] = &discoveryv1.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("service-%d-abc123", i),
 				Namespace: "default",
-				Labels: map[string]string{
-					"kubernetes.io/service-name": fmt.Sprintf("service-%d", i),
-				},
+				Labels:    map[string]string{"kubernetes.io/service-name": fmt.Sprintf("service-%d", i)},
 			},
 			Endpoints: endpoints,
 		}
 	}
-
 	return endpointSlices
 }
 
 // generatePods creates test pods
-func generatePods(count int) []corev1.Pod {
-	pods := make([]corev1.Pod, count)
-
-	for i := 0; i < count; i++ {
-		containers := []corev1.Container{
-			{
-				Name:  "app",
-				Image: "nginx:latest",
-			},
-		}
-
-		// Every 3rd pod has an Envoy sidecar
+func generatePods(count int) []*corev1.Pod {
+	pods := make([]*corev1.Pod, count)
+	for i := range count {
+		containers := []corev1.Container{{Name: "app", Image: "nginx:latest"}}
 		if i%3 == 0 {
 			containers = append(containers, corev1.Container{
 				Name:  "envoy",
 				Image: "envoyproxy/envoy:v1.20.0",
 			})
 		}
-
-		pods[i] = corev1.Pod{
+		pods[i] = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("pod-%d", i),
 				Namespace: "default",
-				Labels: map[string]string{
-					"app": fmt.Sprintf("app-%d", i%100),
-				},
+				Labels:    map[string]string{"app": fmt.Sprintf("app-%d", i%100)},
 			},
-			Spec: corev1.PodSpec{
-				Containers: containers,
-			},
+			Spec: corev1.PodSpec{Containers: containers},
 		}
 	}
-
 	return pods
 }

--- a/edge/pkg/kubernetes/kubernetes_bench_test.go
+++ b/edge/pkg/kubernetes/kubernetes_bench_test.go
@@ -19,11 +19,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/liamawhite/navigator/pkg/logging"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/liamawhite/navigator/pkg/logging"
 )
 
 // BenchmarkGetClusterState_SmallCluster benchmarks cluster state retrieval for a small cluster
@@ -48,32 +49,25 @@ func BenchmarkGetClusterState_VeryLargeCluster(b *testing.B) {
 
 // benchmarkGetClusterState is a helper function that benchmarks cluster state retrieval
 func benchmarkGetClusterState(b *testing.B, numServices, numPods int) {
-	// Create fake clientset with test data
-	clientset := fake.NewSimpleClientset()
-
-	// Create services
+	// Pre-populate all objects so the informer cache is seeded before the benchmark loop
 	services := generateServices(numServices)
-	for _, svc := range services {
-		_, _ = clientset.CoreV1().Services(svc.Namespace).Create(context.TODO(), &svc, metav1.CreateOptions{})
-	}
-
-	// Create endpoint slices
 	endpointSlices := generateEndpointSlices(numServices, numPods)
-	for _, eps := range endpointSlices {
-		_, _ = clientset.DiscoveryV1().EndpointSlices(eps.Namespace).Create(context.TODO(), &eps, metav1.CreateOptions{})
-	}
-
-	// Create pods
 	pods := generatePods(numPods)
-	for _, pod := range pods {
-		_, _ = clientset.CoreV1().Pods(pod.Namespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
+
+	var k8sObjects []runtime.Object
+	for i := range services {
+		k8sObjects = append(k8sObjects, &services[i])
+	}
+	for i := range endpointSlices {
+		k8sObjects = append(k8sObjects, &endpointSlices[i])
+	}
+	for i := range pods {
+		k8sObjects = append(k8sObjects, &pods[i])
 	}
 
-	// Create kubernetes client
-	k8sClient := &Client{
-		clientset: clientset,
-		logger:    logging.For("bench"),
-	}
+	k8sClient := newTestClient(b, k8sObjects, nil)
+
+	_ = logging.For("bench") // ensure logger is initialised
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/edge/pkg/kubernetes/kubernetes_test.go
+++ b/edge/pkg/kubernetes/kubernetes_test.go
@@ -379,7 +379,11 @@ func TestClient_convertEndpointSlicesToInstancesWithMaps(t *testing.T) {
 			}
 			podMap := k8sClient.buildPodMap(podPtrs)
 
-			got := k8sClient.convertEndpointSlicesToInstancesWithMaps(tt.endpointSlices, podMap)
+			epsPtrs := make([]*discoveryv1.EndpointSlice, len(tt.endpointSlices))
+			for i := range tt.endpointSlices {
+				epsPtrs[i] = &tt.endpointSlices[i]
+			}
+			got := k8sClient.convertEndpointSlicesToInstancesWithMaps(epsPtrs, podMap)
 
 			// No error expected since we removed the context parameter
 			if tt.wantErr {
@@ -945,7 +949,7 @@ func TestClient_convertServiceWithMaps_WithIPs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Empty maps for endpoint slices and pods since we're only testing service IP extraction
-			endpointSlicesByService := make(map[string][]discoveryv1.EndpointSlice)
+			endpointSlicesByService := make(map[string][]*discoveryv1.EndpointSlice)
 			podsByName := make(map[string]*corev1.Pod)
 
 			result := client.convertServiceWithMaps(tt.service, endpointSlicesByService, podsByName)

--- a/edge/pkg/kubernetes/kubernetes_test.go
+++ b/edge/pkg/kubernetes/kubernetes_test.go
@@ -372,8 +372,12 @@ func TestClient_convertEndpointSlicesToInstancesWithMaps(t *testing.T) {
 				logger:    logging.For("test"),
 			}
 
-			// Build pod map from test data
-			podMap := k8sClient.buildPodMap(tt.pods)
+			// Build pod map from test data (convert value slice to pointer slice)
+			podPtrs := make([]*corev1.Pod, len(tt.pods))
+			for i := range tt.pods {
+				podPtrs[i] = &tt.pods[i]
+			}
+			podMap := k8sClient.buildPodMap(podPtrs)
 
 			got := k8sClient.convertEndpointSlicesToInstancesWithMaps(tt.endpointSlices, podMap)
 

--- a/edge/pkg/kubernetes/testhelpers_test.go
+++ b/edge/pkg/kubernetes/testhelpers_test.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Navigator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/liamawhite/navigator/pkg/logging"
+	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/stretchr/testify/require"
+)
+
+// newTestClient creates a Client with informers started and caches synced.
+// k8sObjects and istioObjects are pre-populated into the respective fake clientsets
+// before Start is called, so they are immediately visible through the listers.
+func newTestClient(t testing.TB, k8sObjects []runtime.Object, istioObjects []runtime.Object) *Client {
+	t.Helper()
+
+	k8sClientset := fake.NewSimpleClientset(k8sObjects...)
+	istioClientset := istiofake.NewSimpleClientset(istioObjects...)
+
+	c := &Client{
+		clientset:   k8sClientset,
+		istioClient: istioClientset,
+		logger:      logging.For("test"),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	require.NoError(t, c.Start(ctx))
+	return c
+}

--- a/edge/pkg/service/service.go
+++ b/edge/pkg/service/service.go
@@ -34,6 +34,7 @@ import (
 
 // KubernetesClient interface for dependency injection
 type KubernetesClient interface {
+	Start(ctx context.Context) error
 	GetClusterState(ctx context.Context) (*v1alpha1.ClusterState, error)
 	GetClusterStateWithMetrics(ctx context.Context, metricsProvider interfaces.MetricsProvider) (*v1alpha1.ClusterState, error)
 	GetClusterName(ctx context.Context) (string, error)
@@ -93,7 +94,7 @@ func NewEdgeService(config Config, k8sClient KubernetesClient, proxyService Prox
 
 // Start starts the edge service and begins cluster state synchronization
 func (e *EdgeService) Start() error {
-	// Auto-discover cluster name from Istio
+	// Auto-discover cluster name from Istio (direct API call, before informers start)
 	clusterName, err := e.k8sClient.GetClusterName(e.ctx)
 	if err != nil {
 		return fmt.Errorf("failed to auto-discover cluster name from Istio control plane: %w", err)
@@ -101,6 +102,11 @@ func (e *EdgeService) Start() error {
 	e.clusterName = clusterName
 
 	e.logger.Info("starting edge service", "cluster_name", e.clusterName, "manager_endpoint", e.config.GetManagerEndpoint())
+
+	// Start informers and wait for cache sync
+	if err := e.k8sClient.Start(e.ctx); err != nil {
+		return fmt.Errorf("failed to start kubernetes informers: %w", err)
+	}
 
 	// Connect to manager
 	if err := e.connect(); err != nil {

--- a/edge/pkg/service/service_test.go
+++ b/edge/pkg/service/service_test.go
@@ -56,6 +56,10 @@ func (m *mockKubernetesClient) GetClusterName(ctx context.Context) (string, erro
 	return "test-cluster", nil
 }
 
+func (m *mockKubernetesClient) Start(_ context.Context) error {
+	return nil
+}
+
 // mockProxyService implements the ProxyService interface for testing
 type mockProxyService struct {
 	proxyConfig *types.ProxyConfig


### PR DESCRIPTION
## Summary

- Replaces 14 parallel `List` API calls on every sync tick with `SharedInformerFactory` caches (k8s + Istio)
- The edge establishes a watch-backed in-memory cache at startup via `Client.Start(ctx)`; `GetClusterState` reads from that cache without hitting the API server
- Adds `Start(ctx context.Context) error` to the `KubernetesClient` interface and calls it in `EdgeService.Start` before the sync loop begins
- Converts all `fetchXxx(wg, errChan)` goroutine methods in `istio.go` to synchronous `listXxx()` lister reads
- Updates tests to use a `newTestClient` helper that seeds fake clientsets and syncs informer caches before assertions

## Test plan

- [ ] `go build ./edge/...` — compiles clean
- [ ] `go test ./edge/...` — all tests pass
- [ ] `go vet ./edge/...` — no vet issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)