### PR TITLE
ci: bump install-nix-action v22/v25 → v27 across all workflows

### DIFF
--- a/.github/workflows/hygiene.yml
+++ b/.github/workflows/hygiene.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Install Nix
-      uses: cachix/install-nix-action@v25
+      uses: cachix/install-nix-action@v27
     
     - name: Check code formatting
       run: make format
@@ -35,7 +35,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Install Nix
-      uses: cachix/install-nix-action@v25
+      uses: cachix/install-nix-action@v27
     
     - name: Run linting
       run: make lint
@@ -49,7 +49,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Install Nix
-      uses: cachix/install-nix-action@v25
+      uses: cachix/install-nix-action@v27
 
     - name: Check generation
       run: make generate

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v25
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v25
+        uses: cachix/install-nix-action@v27
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v25
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v25
+        uses: cachix/install-nix-action@v27
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Install Nix
-      uses: cachix/install-nix-action@v25
+      uses: cachix/install-nix-action@v27
     
     - name: Run unit tests
       run: make test-unit
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Install Nix
-      uses: cachix/install-nix-action@v25
+      uses: cachix/install-nix-action@v27
     
     - name: Run UI tests
       run: make test-ui
@@ -46,7 +46,7 @@ jobs:
         fetch-depth: 0
     
     - name: Install Nix
-      uses: cachix/install-nix-action@v25
+      uses: cachix/install-nix-action@v27
     
     - name: Test release build
       run: nix develop --command goreleaser release --snapshot --clean --parallelism 2


### PR DESCRIPTION
## Summary

- Bumps `cachix/install-nix-action` to v27 across all workflows (release, nightly, test, hygiene)
- v22/v25 install Nix < 2.18; v27 installs Nix ≥ 2.18 which is required by the updated nixpkgs snapshot in `flake.lock`
- Release of v0.4.0 failed with: `This version of Nixpkgs requires an implementation of Nix with the following features: builtins.nixVersion reports at least 2.18. You are evaluating with Nix 2.16.1`

## Test plan

- [ ] Merge and re-tag v0.4.0 to verify release workflow completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)